### PR TITLE
Build(presets): Adding CMake presets for compilation with ASan/MSan

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -2,17 +2,8 @@
   "version": 6,
   "configurePresets": [
     {
-      "name": "base",
-      "hidden": true,
-      "binaryDir": "${sourceDir}/build/${presetName}",
-      "cacheVariables": {
-        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
-      }
-    },
-    {
       "name": "asan",
       "displayName": "AddressSanitizer Build",
-      "inherits": "base",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
         "CMAKE_CXX_FLAGS": "-fsanitize=address -fno-omit-frame-pointer -g",
@@ -26,7 +17,6 @@
     {
       "name": "msan",
       "displayName": "MemorySanitizer Build",
-      "inherits": "base",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
         "CMAKE_CXX_FLAGS": "-fsanitize=memory -fno-omit-frame-pointer -g -O2",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,48 @@
+{
+  "version": 6,
+  "configurePresets": [
+    {
+      "name": "base",
+      "hidden": true,
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "cacheVariables": {
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+      }
+    },
+    {
+      "name": "asan",
+      "displayName": "AddressSanitizer Build",
+      "inherits": "base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_CXX_FLAGS": "-fsanitize=address -fno-omit-frame-pointer -g",
+        "CMAKE_C_FLAGS": "-fsanitize=address -fno-omit-frame-pointer -g",
+        "CMAKE_LINKER_FLAGS": "-fsanitize=address"
+      },
+      "environment": {
+        "ASAN_OPTIONS": "detect_leaks=1:abort_on_error=1"
+      }
+    },
+    {
+      "name": "msan",
+      "displayName": "MemorySanitizer Build",
+      "inherits": "base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_CXX_FLAGS": "-fsanitize=memory -fno-omit-frame-pointer -g -O2",
+        "CMAKE_C_FLAGS": "-fsanitize=memory -fno-omit-frame-pointer -g -O2",
+        "CMAKE_LINKER_FLAGS": "-fsanitize=memory"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "asan",
+      "configurePreset": "asan"
+    },
+    {
+      "name": "msan",
+      "configurePreset": "msan"
+    }
+  ]
+}


### PR DESCRIPTION
Добавляю два preset'а для Debug сборки вместе с AddressSanitizer/MemorySanitizer

Команды для сборки
```
cmake --preset asan
cmake --build --preset asan
```
или
```
cmake --preset msan
cmake --build --preset msan
```
Сборка идёт в соответствующую папку ./build/${presetName}

Для работы с ASan необходимо дополнить переменную окружения LD_PRELOAD
```
export LD_PRELOAD="/path/to/libasan"
```
Путь до динамической библиотеки libasan можно узнать с помощью
```
ldconfig -p | grep libasan
```
Возможна сборка с подключением динамической библиотеки (не будет необходимости возиться с LD_PRELOAD), однако, в этом случае [появляются проблемы](https://github.com/google/sanitizers/wiki/AddressSanitizerAsDso) с производительностью и возникают проблемы с компиляцией в случае использования ряда других флагов.

Сборка MSan "из коробки" возможна только при использовании определённых компиляторов, например Clang. GCC, к сожалению, таким функционалом обделён по умолчанию.
В случае сборки проекта с MSan рекомендуется определить используемый компилятор с помощью переменных окружения или добавить соответствующие параметры в CMakePresets.json, например
```
    {
      "name": "base",
      "hidden": true,
      "binaryDir": "${sourceDir}/build/${presetName}",
      "CMAKE_C_COMPILER": "clang",
      "CMAKE_CXX_COMPILER": "clang++",
      "cacheVariables": {
        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
      }
```

==================================================================================

I am adding two presets for Debug builds along with AddressSanitizer/MemorySanitizer.

Commands for building:
```
cmake --preset asan
cmake --build --preset asan
```
or
```
cmake --preset msan
cmake --build --preset msan
```
The build goes to the corresponding folder ./build/${presetName}

To work with ASan, you need to run executable with LD_PRELOAD=path/to/libasan
```
export LD_PRELOAD="/path/to/libasan"
```
The path to the libasan dynamic library can be found using
```
ldconfig -p | grep libasan
```
It is possible to build with a dynamic library connection (no need to mess with LD_PRELOAD), but in [this case](https://github.com/google/sanitizers/wiki/AddressSanitizerAsDso), performance issues may arise. This can even lead to compilation problems if flags for static linking are used.

Building MSan ‘out of the box’ is only possible when using certain compilers, such as Clang. Unfortunately, GCC does not have this functionality by default.
When building a project with MSan, it is recommended to specify the compiler or add the appropriate parameters to CMakePresets.json, for example
```
    {
      ‘name’: ‘base’,
      ‘hidden’: true,
      ‘binaryDir’: ‘${sourceDir}/build/${presetName}’,
      ‘CMAKE_C_COMPILER’: ‘clang’,
      ‘CMAKE_CXX_COMPILER’: ‘clang++’,
      ‘cacheVariables’: {
        ‘CMAKE_EXPORT_COMPILE_COMMANDS’: ‘ON’
      }
```