### PR TITLE
optimize CI image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ FROM debian:${TAG} AS setup
 SHELL [ "/bin/bash", "-c"]
 RUN apt-get update && apt-get install -y        \
     bison build-essential flex git python3-dev  \
-    libxml2-dev wget zlib1g-dev cmake           \
+    libxml2-dev wget zlib1g-dev cmake            \
     libboost-all-dev libcrypto++-dev            \
     libfox-1.6-dev libgdal-dev libproj-dev      \
     libgeographiclib-dev libxerces-c-dev        \
@@ -26,11 +26,15 @@ ARG SUMO_TAG=v1_21_0
 # OMNeT version (github tag)
 ARG OMNETPP_TAG=omnetpp-5.6.2
 
+RUN cd /usr/local/bin && \
+    git clone --depth 1 --branch v0.23.0 https://github.com/ZedThree/clang-tidy-review.git /tmp/clang-tidy-review && \
+    python3 -m pip install --no-cache-dir --break-system-packages /tmp/clang-tidy-review/post/clang_tidy_review
+
 RUN git clone --recurse --depth 1 --branch ${OMNETPP_TAG} https://github.com/omnetpp/omnetpp
 WORKDIR /omnetpp
 RUN mv configure.user.dist configure.user
-RUN source setenv -f                                            \
-    && ./configure WITH_QTENV=no WITH_OSG=no WITH_OSGEARTH=no   \
+RUN source setenv -f                                                                \
+    && ./configure WITH_QTENV=no WITH_TKENV=no WITH_OSG=no WITH_OSGEARTH=no WITH_MPI=no \
     && make -j$(nproc --all) base MODE=release
 
 WORKDIR /
@@ -40,6 +44,7 @@ RUN cmake -B build .                                    \
         -G Ninja                                        \
         -DCMAKE_BUILD_CONFIG=Release                    \
         -DCMAKE_INSTALL_PREFIX=/sumo-prefix             \
+        -DENABLE_GUI=OFF                                \
         -DENABLE_CS_BINDINGS=OFF                        \
         -DENABLE_JAVA_BINDINGS=OFF                      \
         -DENABLE_PYTHON_BINDINGS=OFF                    \
@@ -47,7 +52,7 @@ RUN cmake -B build .                                    \
     && cmake --build build --parallel $(nproc --all)    \
     && cmake --install build
 
-FROM setup AS final
+FROM gcr.io/distroless/cc-debian12:debug AS final
 
 COPY --from=build /omnetpp/bin /omnetpp/bin
 COPY --from=build /omnetpp/include /omnetpp/include
@@ -57,12 +62,9 @@ COPY --from=build /omnetpp/Makefile.inc /omnetpp
 
 COPY --from=build /sumo-prefix/ /usr/local
 
-RUN cd /usr/local/bin && \
-    curl -sSL -O https://raw.githubusercontent.com/llvm/llvm-project/main/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py && \
-    chmod +x clang-tidy-diff.py \
-    git clone --depth 1 --branch v0.23.0 https://github.com/ZedThree/clang-tidy-review.git /tmp/clang-tidy-review && \
-    python3 -m pip install --no-cache-dir --break-system-packages /tmp/clang-tidy-review/post/clang_tidy_review && \
-    rm -rf /tmp/clang-tidy-review
+COPY --from=build /usr/bin/python3* /usr/bin/
+COPY --from=build /usr/lib/python3* /usr/lib/python3
+COPY --from=build /usr/local/lib/python3* /usr/local/lib/python3
 
 ENV PATH=/omnetpp/bin:$PATH
 ENV SUMO_HOME=/usr/local/share/sumo

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ FROM debian:${TAG} AS setup
 SHELL [ "/bin/bash", "-c"]
 RUN apt-get update && apt-get install -y        \
     bison build-essential flex git python3-dev  \
-    libxml2-dev wget zlib1g-dev cmake            \
+    libxml2-dev wget zlib1g-dev cmake           \
     libboost-all-dev libcrypto++-dev            \
     libfox-1.6-dev libgdal-dev libproj-dev      \
     libgeographiclib-dev libxerces-c-dev        \
@@ -26,14 +26,13 @@ ARG SUMO_TAG=v1_21_0
 # OMNeT version (github tag)
 ARG OMNETPP_TAG=omnetpp-5.6.2
 
-RUN cd /usr/local/bin && \
-    git clone --depth 1 --branch v0.23.0 https://github.com/ZedThree/clang-tidy-review.git /tmp/clang-tidy-review && \
+RUN git clone --depth 1 --branch v0.23.0 https://github.com/ZedThree/clang-tidy-review.git /tmp/clang-tidy-review && \
     python3 -m pip install --no-cache-dir --break-system-packages /tmp/clang-tidy-review/post/clang_tidy_review
 
 RUN git clone --recurse --depth 1 --branch ${OMNETPP_TAG} https://github.com/omnetpp/omnetpp
 WORKDIR /omnetpp
 RUN mv configure.user.dist configure.user
-RUN source setenv -f                                                                \
+RUN source setenv -f \
     && ./configure WITH_QTENV=no WITH_TKENV=no WITH_OSG=no WITH_OSGEARTH=no WITH_MPI=no \
     && make -j$(nproc --all) base MODE=release
 


### PR DESCRIPTION
1.Switched to gcr.io/distroless/cc-debian12:debug to minimize image size and security surface while keeping BusyBox for CI script compatibility.
2. Added the -DENABLE_GUI=OFF flag for SUMO Build to disable all graphical utilities and dependencies (FOX, OpenGL), which are unnecessary for CI.
3. Added WITH_TKENV=no and WITH_MPI=no to OMNeT++ Configuration to exclude the legacy GUI and parallel processing overhead, further streamlining the build.
4. Refactored the installation of CI tools and Python artifacts.