### PR TITLE
Optimize devcontainers builds (including cached builds)

### DIFF
--- a/.devcontainer/arch-linux/Dockerfile
+++ b/.devcontainer/arch-linux/Dockerfile
@@ -28,26 +28,29 @@ RUN pacman -Syu --noconfirm     \
 FROM setup AS build
 
 # SUMO version (github tag)
-ARG SUMO_TAG=v1_23_0
+ARG SUMO_TAG=v1_24_0
 # OMNeT version (github tag)
 ARG OMNETPP_TAG=omnetpp-5.6.2
 # GeographicLib version (github tag)
 ARG GEOGRAPHICLIB_TAG=v2.5
 
-RUN git clone --recurse --depth 1 --branch ${OMNETPP_TAG} https://github.com/omnetpp/omnetpp
-WORKDIR /omnetpp
-RUN mv configure.user.dist configure.user
-RUN source setenv -f && ./configure WITH_OSGEARTH=no && make -j$(nproc --all)
+RUN git clone --recurse --depth 1 --branch ${OMNETPP_TAG} https://github.com/omnetpp/omnetpp \
+    && cd omnetpp \
+    && mv configure.user.dist configure.user \
+    && source setenv -f && ./configure WITH_OSGEARTH=no && make -j$(nproc --all) \
+    && rm -rf .git
 
-WORKDIR /
-RUN git clone --recurse --depth 1 --branch ${SUMO_TAG} https://github.com/eclipse-sumo/sumo
-WORKDIR /sumo
-RUN cmake -B build . && cmake --build build --parallel $(nproc --all)
+RUN git clone --recurse --depth 1 --branch ${SUMO_TAG} https://github.com/eclipse-sumo/sumo \
+    && cd sumo \
+    && cmake -B build . -DCMAKE_CXX_FLAGS="-fpermissive" && cmake --build build --parallel 4 \
+    && cmake --install build --prefix /opt/inst \
+    && cd .. && rm -rf sumo
 
-WORKDIR /
-RUN git clone --recurse --depth 1 --branch ${GEOGRAPHICLIB_TAG} https://github.com/geographiclib/geographiclib
-WORKDIR /geographiclib
-RUN cmake -B build . && cmake --build build --parallel $(nproc --all)
+RUN git clone --recurse --depth 1 --branch ${GEOGRAPHICLIB_TAG} https://github.com/geographiclib/geographiclib \
+    && cd geographiclib \
+    && cmake -B build . && cmake --build build --parallel $(nproc --all) \
+    && cmake --install build --prefix /opt/inst \
+    && cd .. && rm -rf geographiclib
 
 ######################
 # Installation stage #
@@ -64,11 +67,7 @@ COPY --from=build /omnetpp/lib /omnetpp/lib
 COPY --from=build /omnetpp/images /omnetpp/images
 COPY --from=build /omnetpp/Makefile.inc /omnetpp
 
-COPY --from=build /sumo /sumo
-RUN cmake --install /sumo/build
-
-COPY --from=build /geographiclib /geographiclib
-RUN cmake --install /geographiclib/build
+COPY --from=build /opt/inst/ /usr/local/
 
 RUN groupadd sudo && useradd -m -G sudo ${USER}
 RUN echo "${USER} ALL=(ALL:ALL) NOPASSWD: ALL" | sudo tee /etc/sudoers.d/${USER}
@@ -92,7 +91,7 @@ USER ${USER}
 WORKDIR /workspace/artery
 
 # Which CMake configs to prebuild; space-separated, e.g. "Debug Release"
-ARG BUILD_CONFIGS="Debug"
+ARG BUILD_CONFIGS="RelWithDebInfo"
 
 COPY --chown=${USER} . .
 

--- a/.devcontainer/arch-linux/Dockerfile
+++ b/.devcontainer/arch-linux/Dockerfile
@@ -28,7 +28,7 @@ RUN pacman -Syu --noconfirm     \
 FROM setup AS build
 
 # SUMO version (github tag)
-ARG SUMO_TAG=v1_24_0
+ARG SUMO_TAG=v1_26_0
 # OMNeT version (github tag)
 ARG OMNETPP_TAG=omnetpp-5.6.2
 # GeographicLib version (github tag)
@@ -42,7 +42,7 @@ RUN git clone --recurse --depth 1 --branch ${OMNETPP_TAG} https://github.com/omn
 
 RUN git clone --recurse --depth 1 --branch ${SUMO_TAG} https://github.com/eclipse-sumo/sumo \
     && cd sumo \
-    && cmake -B build . -DCMAKE_CXX_FLAGS="-fpermissive" && cmake --build build --parallel 4 \
+    && cmake -B build . && cmake --build build \
     && cmake --install build --prefix /opt/inst \
     && cd .. && rm -rf sumo
 

--- a/.devcontainer/arch-linux/Dockerfile
+++ b/.devcontainer/arch-linux/Dockerfile
@@ -42,7 +42,7 @@ RUN git clone --recurse --depth 1 --branch ${OMNETPP_TAG} https://github.com/omn
 
 RUN git clone --recurse --depth 1 --branch ${SUMO_TAG} https://github.com/eclipse-sumo/sumo \
     && cd sumo \
-    && cmake -B build . && cmake --build build \
+    && cmake -B build . && cmake --build build --parallel $(nproc --all) \
     && cmake --install build --prefix /opt/inst \
     && cd .. && rm -rf sumo
 

--- a/.devcontainer/debian/Dockerfile
+++ b/.devcontainer/debian/Dockerfile
@@ -21,19 +21,21 @@ RUN pip install --break-system-packages conan
 FROM setup AS build
 
 # SUMO version (github tag)
-ARG SUMO_TAG=v1_23_0
+ARG SUMO_TAG=v1_24_0
 # OMNeT version (github tag)
 ARG OMNETPP_TAG=omnetpp-5.6.2
 
-RUN git clone --recurse --depth 1 --branch ${OMNETPP_TAG} https://github.com/omnetpp/omnetpp
-WORKDIR /omnetpp
-RUN mv configure.user.dist configure.user
-RUN source setenv -f && ./configure WITH_OSGEARTH=no && make -j$(nproc --all)
+RUN git clone --recurse --depth 1 --branch ${OMNETPP_TAG} https://github.com/omnetpp/omnetpp \
+    && cd omnetpp \
+    && mv configure.user.dist configure.user \
+    && source setenv -f && ./configure WITH_OSGEARTH=no && make -j$(nproc --all) \
+    && rm -rf .git
 
-WORKDIR /
-RUN git clone --recurse --depth 1 --branch ${SUMO_TAG} https://github.com/eclipse-sumo/sumo
-WORKDIR /sumo
-RUN cmake -B build . && cmake --build build --parallel $(nproc --all)
+RUN git clone --recurse --depth 1 --branch ${SUMO_TAG} https://github.com/eclipse-sumo/sumo \
+    && cd sumo \
+    && cmake -B build . && cmake --build build --parallel $(nproc --all) \
+    && cmake --install build --prefix /opt/sumo \
+    && cd .. && rm -rf sumo
 
 ######################
 # Installation stage #
@@ -50,8 +52,7 @@ COPY --from=build /omnetpp/lib /omnetpp/lib
 COPY --from=build /omnetpp/images /omnetpp/images
 COPY --from=build /omnetpp/Makefile.inc /omnetpp
 
-COPY --from=build /sumo /sumo
-RUN cmake --install /sumo/build
+COPY --from=build /opt/sumo/ /usr/local/
 
 RUN useradd -m -G sudo ${USER}
 RUN echo "${USER} ALL=(ALL:ALL) NOPASSWD: ALL" | sudo tee /etc/sudoers.d/${USER}
@@ -75,7 +76,7 @@ USER ${USER}
 WORKDIR /workspace/artery
 
 # Which CMake configs to prebuild; space-separated, e.g. "Debug Release"
-ARG BUILD_CONFIGS="Debug"
+ARG BUILD_CONFIGS="RelWithDebInfo"
 
 COPY --chown=${USER} . .
 

--- a/.devcontainer/debian/Dockerfile
+++ b/.devcontainer/debian/Dockerfile
@@ -33,7 +33,7 @@ RUN git clone --recurse --depth 1 --branch ${OMNETPP_TAG} https://github.com/omn
 
 RUN git clone --recurse --depth 1 --branch ${SUMO_TAG} https://github.com/eclipse-sumo/sumo \
     && cd sumo \
-    && cmake -B build . && cmake --build build \
+    && cmake -B build . && cmake --build build --parallel $(nproc --all) \
     && cmake --install build --prefix /opt/sumo \
     && cd .. && rm -rf sumo
 

--- a/.devcontainer/debian/Dockerfile
+++ b/.devcontainer/debian/Dockerfile
@@ -33,7 +33,7 @@ RUN git clone --recurse --depth 1 --branch ${OMNETPP_TAG} https://github.com/omn
 
 RUN git clone --recurse --depth 1 --branch ${SUMO_TAG} https://github.com/eclipse-sumo/sumo \
     && cd sumo \
-    && cmake -B build . && cmake --build build --parallel $(nproc --all) \
+    && cmake -B build . && cmake --build build \
     && cmake --install build --prefix /opt/sumo \
     && cd .. && rm -rf sumo
 


### PR DESCRIPTION
1.Replaced direct source directory copying with a prefix-based installation.
2. Chained  commands into single RUN instructions.
3. Configured the cached-build stage to use RelWithDebInfo.
