### PR TITLE
SIonna: INET shapes conversion into .obj shapes

### DIFF
--- a/src/cavise/sionna/bridge/CMakeLists.txt
+++ b/src/cavise/sionna/bridge/CMakeLists.txt
@@ -33,11 +33,16 @@ foreach(_mode IN ITEMS ${SIONNA_BRIDGE_COMPILATION_MODES})
                 bindings/Material.cc
                 bindings/Scene.cc
                 bindings/SceneObject.cc
+                meshes/CubeMesh.cc
+                meshes/PolyhedronMesh.cc
+                meshes/PrismMesh.cc
+                meshes/SphereMesh.cc
             PUBLIC
                 Fwd.h
                 Helpers.h
                 Compat.h
                 Defaulted.h
+                EnvironmentMeshGenerator.h
                 capabilities/Calling.h
                 capabilities/Core.h
                 capabilities/Defaulted.h

--- a/src/cavise/sionna/bridge/EnvironmentMeshGenerator.h
+++ b/src/cavise/sionna/bridge/EnvironmentMeshGenerator.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <cavise/sionna/bridge/Fwd.h>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace artery::sionna::meshes {
+
+std::string generateObjCube(float x, float y, float z);
+std::string generateObjSphere(float radius);
+std::string generateObjPrism(float height, const std::vector<float>& vertices);
+std::string generateObjPolyhedron(const std::vector<float>& vertices);
+
+} // namespace artery::sionna::meshes

--- a/src/cavise/sionna/bridge/meshes/CubeMesh.cc
+++ b/src/cavise/sionna/bridge/meshes/CubeMesh.cc
@@ -5,11 +5,11 @@ namespace artery::sionna::meshes {
 std::string generateObjCube(float x, float y, float z) {
     std::ostringstream oss;
     oss << "o Cube\n";
-    
-    float sx = x * 0.5f;
-    float sy = y * 0.5f;
-    float sz = z * 0.5f;
-    
+
+    float sx = x * 0.5F;
+    float sy = y * 0.5F;
+    float sz = z * 0.5F;
+
     oss << "v " << -sx << " " << -sy << " " << -sz << "\n"; // 1
     oss << "v " <<  sx << " " << -sy << " " << -sz << "\n"; // 2
     oss << "v " <<  sx << " " <<  sy << " " << -sz << "\n"; // 3

--- a/src/cavise/sionna/bridge/meshes/CubeMesh.cc
+++ b/src/cavise/sionna/bridge/meshes/CubeMesh.cc
@@ -1,0 +1,38 @@
+#include <cavise/sionna/bridge/EnvironmentMeshGenerator.h>
+
+namespace artery::sionna::meshes {
+
+std::string generateObjCube(float x, float y, float z) {
+    std::ostringstream oss;
+    oss << "o Cube\n";
+    
+    float sx = x * 0.5f;
+    float sy = y * 0.5f;
+    float sz = z * 0.5f;
+    
+    oss << "v " << -sx << " " << -sy << " " << -sz << "\n"; // 1
+    oss << "v " <<  sx << " " << -sy << " " << -sz << "\n"; // 2
+    oss << "v " <<  sx << " " <<  sy << " " << -sz << "\n"; // 3
+    oss << "v " << -sx << " " <<  sy << " " << -sz << "\n"; // 4
+    oss << "v " << -sx << " " << -sy << " " <<  sz << "\n"; // 5
+    oss << "v " <<  sx << " " << -sy << " " <<  sz << "\n"; // 6
+    oss << "v " <<  sx << " " <<  sy << " " <<  sz << "\n"; // 7
+    oss << "v " << -sx << " " <<  sy << " " <<  sz << "\n"; // 8
+    
+    // (-Z)
+    oss << "f 1 2 3\nf 1 3 4\n";
+    // (+Z)
+    oss << "f 5 6 7\nf 5 7 8\n";
+    // (-X)
+    oss << "f 1 4 8\nf 1 8 5\n";
+    // (+X)
+    oss << "f 2 6 7\nf 2 7 3\n";
+    // (-Y)
+    oss << "f 1 5 6\nf 1 6 2\n";
+    // (+Y)
+    oss << "f 4 3 7\nf 4 7 8\n";
+    
+    return oss.str();
+}
+
+}

--- a/src/cavise/sionna/bridge/meshes/CubeMesh.cc
+++ b/src/cavise/sionna/bridge/meshes/CubeMesh.cc
@@ -1,4 +1,6 @@
 #include <cavise/sionna/bridge/EnvironmentMeshGenerator.h>
+#include <string>
+#include <sstream>
 
 namespace artery::sionna::meshes {
 
@@ -6,9 +8,9 @@ std::string generateObjCube(float x, float y, float z) {
     std::ostringstream oss;
     oss << "o Cube\n";
 
-    float sx = x * 0.5F;
-    float sy = y * 0.5F;
-    float sz = z * 0.5F;
+    float const sx = x * 0.5F;
+    float const sy = y * 0.5F;
+    float const sz = z * 0.5F;
 
     oss << "v " << -sx << " " << -sy << " " << -sz << "\n"; // 1
     oss << "v " <<  sx << " " << -sy << " " << -sz << "\n"; // 2

--- a/src/cavise/sionna/bridge/meshes/PolyhedronMesh.cc
+++ b/src/cavise/sionna/bridge/meshes/PolyhedronMesh.cc
@@ -234,7 +234,8 @@ std::string generateObjPolyhedron(const std::vector<float>& vertices) {
             return it->second;
         }
         outVerts.push_back(pts[origIdx]);
-        int oi = 0 = static_cast<int>(outVerts.size()); // 1-based
+        int oi = 0;
+        oi = static_cast<int>(outVerts.size()); // 1-based
         indexMap[origIdx] = oi;
         return oi;
     };

--- a/src/cavise/sionna/bridge/meshes/PolyhedronMesh.cc
+++ b/src/cavise/sionna/bridge/meshes/PolyhedronMesh.cc
@@ -2,7 +2,6 @@
 #include <cavise/sionna/bridge/Fwd.h>
 #include <cavise/sionna/bridge/Helpers.h>
 #include <cmath>
-#include <tuple>
 
 using Float = float;
 using Spectrum = mitsuba::Color<Float, 3>;
@@ -15,7 +14,9 @@ namespace artery::sionna::meshes {
 
 Vector3f normalized(const Vector3f& p) {
         float n = norm(p);
-        if (n < 1e-9f) return Vector3f(0.f);
+        if (n < 1e-9F) {
+            return Vector3f(0.F);
+        }
         return normalize(p);
 }
 
@@ -35,8 +36,8 @@ Vector3f centroid(const std::vector<Vector3f>& pts) {
 // ---------------------------------------------------------------------------
 
 struct Face {
-    int a, b, c;    // indices into the global point array
-    Vector3f normal;    // outward normal
+    int a{}, b{}, c{}; // indices into the global point array
+    Vector3f normal{}; // outward normal
 };
 
 // Signed volume of tetrahedron formed by face (a,b,c) and point d
@@ -46,7 +47,7 @@ float signedVolume(const Vector3f& a, const Vector3f& b, const Vector3f& c, cons
 
 // Returns true if point p is strictly above face (i.e. on the outward side)
 bool isVisible(const Face& f, const Vector3f& p, const std::vector<Vector3f>& pts) {
-    return dot(f.normal, p - pts[f.a]) > 1e-7f;
+    return dot(f.normal, p - pts[f.a]) > 1e-7F;
 }
 
 std::vector<Face> buildConvexHull(const std::vector<Vector3f>& pts) {
@@ -58,23 +59,26 @@ std::vector<Face> buildConvexHull(const std::vector<Vector3f>& pts) {
 
     // --- Build initial tetrahedron ---
     // Find 4 non-coplanar points
-    int p0 = 0, p1 = -1, p2 = -1, p3 = -1;
+    int p0 = 0;
+    int p1 = -1;
+    int p2 = -1;
+    int p3 = -1;
 
     for (int i = 1; i < n && p1 < 0; ++i) {
-        if (norm(pts[i] - pts[p0]) > 1e-7f) {
+        if (norm(pts[i] - pts[p0]) > 1e-7F) {
             p1 = i;
         }
     }
 
     for (int i = 1; i < n && p2 < 0; ++i) {
-        if (i != p1 && norm(cross(pts[i] - pts[p0], pts[p1] - pts[p0])) > 1e-7f) {
+        if (i != p1 && norm(cross(pts[i] - pts[p0], pts[p1] - pts[p0])) > 1e-7F) {
             p2 = i;
         }
     }
 
     for (int i = 1; i < n && p3 < 0; ++i) {
         if (i != p1 && i != p2 &&
-            std::abs(dot(pts[i] - pts[p0], cross(pts[p1] - pts[p0], pts[p2] - pts[p0]))) > 1e-7f) {
+            std::abs(dot(pts[i] - pts[p0], cross(pts[p1] - pts[p0], pts[p2] - pts[p0]))) > 1e-7F) {
             p3 = i;
         }
     }
@@ -91,7 +95,7 @@ std::vector<Face> buildConvexHull(const std::vector<Vector3f>& pts) {
         Vector3f n = normalized(cross(pts[b] - pts[a], pts[c] - pts[a]));
         // Flip if normal points inward
         if (dot(n, pts[a] - innerPoint) < 0) {
-            n = n * -1.0f, std::swap(b, c);
+            n = n * -1.0F, std::swap(b, c);
         }
         return {a, b, c, n};
     };
@@ -118,22 +122,31 @@ std::vector<Face> buildConvexHull(const std::vector<Vector3f>& pts) {
                 anyVisible = true;
             }
         }
-        if (!anyVisible) continue; // point already inside hull
+        if (!anyVisible) {
+            continue; // point already inside hull
+        }
 
         // Find horizon edges: edges shared by exactly one visible face
         // Represent edge as ordered pair (min,max) + winding
         struct Edge { int a, b; };
         std::vector<Edge> horizon;
         for (int f = 0; f < (int)hull.size(); ++f) {
-            if (!visible[f]) continue;
+            if (!visible[f]) {
+                continue;
+            }
             int tri[3] = {hull[f].a, hull[f].b, hull[f].c};
             for (int e = 0; e < 3; ++e) {
-                int ea = tri[e], eb = tri[(e + 1) % 3];
+                int ea = tri[e];
+                int eb = tri[(e + 1) % 3];
                 // Check if the adjacent face (sharing ea-eb reversed) is not visible
                 bool adjVisible = false;
                 for (int g = 0; g < (int)hull.size(); ++g) {
-                    if (!visible[g]) continue;
-                    if (g == f) continue;
+                    if (!visible[g]) {
+                        continue;
+                    }
+                    if (g == f) {
+                        continue;
+                    }
                     int tri2[3] = {hull[g].a, hull[g].b, hull[g].c};
                     for (int e2 = 0; e2 < 3; ++e2) {
                         if (tri2[e2] == eb && tri2[(e2 + 1) % 3] == ea) {
@@ -141,7 +154,9 @@ std::vector<Face> buildConvexHull(const std::vector<Vector3f>& pts) {
                             break;
                         }
                     }
-                    if (adjVisible) break;
+                    if (adjVisible) {
+                        break;
+                    }
                 }
                 if (!adjVisible) {
                     horizon.push_back({ea, eb});
@@ -215,9 +230,11 @@ std::string generateObjPolyhedron(const std::vector<float>& vertices) {
 
     auto getOutIndex = [&](int origIdx) -> int {
         auto it = indexMap.find(origIdx);
-        if (it != indexMap.end()) return it->second;
+        if (it != indexMap.end()) {
+            return it->second;
+        }
         outVerts.push_back(pts[origIdx]);
-        int oi = static_cast<int>(outVerts.size()); // 1-based
+        int oi = 0 = static_cast<int>(outVerts.size()); // 1-based
         indexMap[origIdx] = oi;
         return oi;
     };

--- a/src/cavise/sionna/bridge/meshes/PolyhedronMesh.cc
+++ b/src/cavise/sionna/bridge/meshes/PolyhedronMesh.cc
@@ -22,7 +22,7 @@ Vector3f normalized(const Vector3f& p) {
 
 // Centroid of a list of points
 Vector3f centroid(const std::vector<Vector3f>& pts) {
-    Vector3f c(0.f);
+    Vector3f c(0.F);
     for (const auto& p : pts) {
         c += p;
     }
@@ -89,7 +89,7 @@ std::vector<Face> buildConvexHull(const std::vector<Vector3f>& pts) {
 
     // Orient initial tetrahedron so all normals point outward
     // Use the centroid of the tetrahedron as the interior reference point
-    Vector3f innerPoint = (pts[p0] + pts[p1] + pts[p2] + pts[p3]) * 0.25f;
+    Vector3f innerPoint = (pts[p0] + pts[p1] + pts[p2] + pts[p3]) * 0.25F;
 
     auto makeFace = [&](int a, int b, int c) -> Face {
         Vector3f n = normalized(cross(pts[b] - pts[a], pts[c] - pts[a]));
@@ -187,7 +187,7 @@ std::vector<Face> buildConvexHull(const std::vector<Vector3f>& pts) {
             Vector3f n = normalized(cross(pts[e.b] - pts[e.a], p - pts[e.a]));
             // Ensure outward orientation
             if (dot(n, pts[e.a] - innerPt) < 0) {
-                n = n * -1.0f;
+                n = n * -1.0F;
                 newHull.push_back({e.b, e.a, i, n});
             } else {
                 newHull.push_back({e.a, e.b, i, n});

--- a/src/cavise/sionna/bridge/meshes/PolyhedronMesh.cc
+++ b/src/cavise/sionna/bridge/meshes/PolyhedronMesh.cc
@@ -1,0 +1,237 @@
+#include <cavise/sionna/bridge/EnvironmentMeshGenerator.h>
+#include <cmath>
+#include <tuple>
+
+namespace artery::sionna::meshes {
+
+struct Vec3 {
+    float x, y, z;
+    Vec3(float x = 0, float y = 0, float z = 0) : x(x), y(y), z(z) {}
+    Vec3 operator-(const Vec3& o) const { return {x - o.x, y - o.y, z - o.z}; }
+    Vec3 operator+(const Vec3& o) const { return {x + o.x, y + o.y, z + o.z}; }
+    Vec3 operator*(float s) const { return {x * s, y * s, z * s}; }
+    float dot(const Vec3& o) const { return x * o.x + y * o.y + z * o.z; }
+    Vec3 cross(const Vec3& o) const {
+        return {y * o.z - z * o.y, z * o.x - x * o.z, x * o.y - y * o.x};
+    }
+    float norm() const { return std::sqrt(x * x + y * y + z * z); }
+    Vec3 normalized() const {
+        float n = norm();
+        if (n < 1e-9f) return {0, 0, 0};
+        return {x / n, y / n, z / n};
+    }
+    bool operator==(const Vec3& o) const {
+        return std::abs(x - o.x) < 1e-6f && std::abs(y - o.y) < 1e-6f &&
+               std::abs(z - o.z) < 1e-6f;
+    }
+};
+
+// Centroid of a list of points
+Vec3 centroid(const std::vector<Vec3>& pts) {
+    Vec3 c;
+    for (const auto& p : pts) {
+        c.x += p.x;
+        c.y += p.y;
+        c.z += p.z;
+    }
+    float n = static_cast<float>(pts.size());
+    return {c.x / n, c.y / n, c.z / n};
+}
+
+// ---------------------------------------------------------------------------
+// Minimal incremental convex hull (O(n^2)) for generateObjPolyhedron
+// Builds a list of triangular faces with outward-facing normals.
+// ---------------------------------------------------------------------------
+
+struct Face {
+    int a, b, c;    // indices into the global point array
+    Vec3 normal;    // outward normal
+};
+
+// Signed volume of tetrahedron formed by face (a,b,c) and point d
+float signedVolume(const Vec3& a, const Vec3& b, const Vec3& c, const Vec3& d) {
+    return (b - a).cross(c - a).dot(d - a);
+}
+
+// Returns true if point p is strictly above face (i.e. on the outward side)
+bool isVisible(const Face& f, const Vec3& p, const std::vector<Vec3>& pts) {
+    return f.normal.dot(p - pts[f.a]) > 1e-7f;
+}
+
+std::vector<Face> buildConvexHull(const std::vector<Vec3>& pts) {
+    int n = static_cast<int>(pts.size());
+    assert(n >= 4 && "Need at least 4 non-coplanar points for a convex hull");
+
+    std::vector<Face> hull;
+
+    // --- Build initial tetrahedron ---
+    // Find 4 non-coplanar points
+    int p0 = 0, p1 = -1, p2 = -1, p3 = -1;
+
+    for (int i = 1; i < n && p1 < 0; ++i)
+        if ((pts[i] - pts[p0]).norm() > 1e-7f)
+            p1 = i;
+
+    for (int i = 1; i < n && p2 < 0; ++i)
+        if (i != p1 && (pts[i] - pts[p0]).cross(pts[p1] - pts[p0]).norm() > 1e-7f)
+            p2 = i;
+
+    for (int i = 1; i < n && p3 < 0; ++i)
+        if (i != p1 && i != p2 &&
+            std::abs((pts[i] - pts[p0]).dot((pts[p1] - pts[p0]).cross(pts[p2] - pts[p0]))) > 1e-7f)
+            p3 = i;
+
+    assert(p1 >= 0 && p2 >= 0 && p3 >= 0 && "Points appear to be coplanar or collinear");
+
+    // Orient initial tetrahedron so all normals point outward
+    // Use the centroid of the tetrahedron as the interior reference point
+    Vec3 innerPoint = (pts[p0] + pts[p1] + pts[p2] + pts[p3]) * 0.25f;
+
+    auto makeFace = [&](int a, int b, int c) -> Face {
+        Vec3 n = (pts[b] - pts[a]).cross(pts[c] - pts[a]).normalized();
+        // Flip if normal points inward
+        if (n.dot(pts[a] - innerPoint) < 0)
+            n = n * -1.0f, std::swap(b, c);
+        return {a, b, c, n};
+    };
+
+    hull.push_back(makeFace(p0, p1, p2));
+    hull.push_back(makeFace(p0, p1, p3));
+    hull.push_back(makeFace(p0, p2, p3));
+    hull.push_back(makeFace(p1, p2, p3));
+
+    // --- Incrementally add remaining points ---
+    for (int i = 0; i < n; ++i) {
+        if (i == p0 || i == p1 || i == p2 || i == p3)
+            continue;
+
+        const Vec3& p = pts[i];
+
+        // Collect visible faces and horizon edges
+        std::vector<bool> visible(hull.size(), false);
+        bool anyVisible = false;
+        for (int f = 0; f < (int)hull.size(); ++f) {
+            if (isVisible(hull[f], p, pts)) {
+                visible[f] = true;
+                anyVisible = true;
+            }
+        }
+        if (!anyVisible) continue; // point already inside hull
+
+        // Find horizon edges: edges shared by exactly one visible face
+        // Represent edge as ordered pair (min,max) + winding
+        struct Edge { int a, b; };
+        std::vector<Edge> horizon;
+        for (int f = 0; f < (int)hull.size(); ++f) {
+            if (!visible[f]) continue;
+            int tri[3] = {hull[f].a, hull[f].b, hull[f].c};
+            for (int e = 0; e < 3; ++e) {
+                int ea = tri[e], eb = tri[(e + 1) % 3];
+                // Check if the adjacent face (sharing ea-eb reversed) is not visible
+                bool adjVisible = false;
+                for (int g = 0; g < (int)hull.size(); ++g) {
+                    if (!visible[g]) continue;
+                    if (g == f) continue;
+                    int tri2[3] = {hull[g].a, hull[g].b, hull[g].c};
+                    for (int e2 = 0; e2 < 3; ++e2) {
+                        if (tri2[e2] == eb && tri2[(e2 + 1) % 3] == ea) {
+                            adjVisible = true;
+                            break;
+                        }
+                    }
+                    if (adjVisible) break;
+                }
+                if (!adjVisible)
+                    horizon.push_back({ea, eb});
+            }
+        }
+
+        // Remove visible faces
+        std::vector<Face> newHull;
+        for (int f = 0; f < (int)hull.size(); ++f)
+            if (!visible[f])
+                newHull.push_back(hull[f]);
+
+        // Add new cone faces from horizon edges to the new point
+        Vec3 innerPt = centroid([&]() {
+            std::vector<Vec3> tmp;
+            for (const auto& ff : newHull) {
+                tmp.push_back(pts[ff.a]);
+                tmp.push_back(pts[ff.b]);
+                tmp.push_back(pts[ff.c]);
+            }
+            return tmp;
+        }());
+
+        for (const auto& e : horizon) {
+            Vec3 n = (pts[e.b] - pts[e.a]).cross(p - pts[e.a]).normalized();
+            // Ensure outward orientation
+            if (n.dot(pts[e.a] - innerPt) < 0) {
+                n = n * -1.0f;
+                newHull.push_back({e.b, e.a, i, n});
+            } else {
+                newHull.push_back({e.a, e.b, i, n});
+            }
+        }
+
+        hull = std::move(newHull);
+    }
+
+    return hull;
+}
+
+std::string generateObjPolyhedron(const std::vector<float>& vertices) {
+    assert(vertices.size() % 3 == 0 && "vertices must contain x,y,z triples");
+    assert(vertices.size() >= 12 && "Need at least 4 points for a polyhedron");
+
+    const int n = static_cast<int>(vertices.size()) / 3;
+
+    // Build Vec3 point list
+    std::vector<Vec3> pts;
+    pts.reserve(n);
+    for (int i = 0; i < n; ++i)
+        pts.push_back({vertices[3 * i], vertices[3 * i + 1], vertices[3 * i + 2]});
+
+    // Compute convex hull
+    std::vector<Face> hull = buildConvexHull(pts);
+
+    // -----------------------------------------------------------------------
+    // Build deduplicated vertex list for the OBJ output.
+    // We collect only the hull vertices (some input points may be interior).
+    // -----------------------------------------------------------------------
+    std::vector<Vec3> outVerts;
+    // Map from original index -> output index (1-based)
+    std::unordered_map<int, int> indexMap;
+
+    auto getOutIndex = [&](int origIdx) -> int {
+        auto it = indexMap.find(origIdx);
+        if (it != indexMap.end()) return it->second;
+        outVerts.push_back(pts[origIdx]);
+        int oi = static_cast<int>(outVerts.size()); // 1-based
+        indexMap[origIdx] = oi;
+        return oi;
+    };
+
+    // Pre-pass: register vertices in hull order for deterministic output
+    for (const auto& f : hull) {
+        getOutIndex(f.a);
+        getOutIndex(f.b);
+        getOutIndex(f.c);
+    }
+
+    std::ostringstream obj;
+    obj << "o Polyhedron\n\n";
+
+    // Vertices
+    for (const auto& v : outVerts)
+        obj << "v " << v.x << " " << v.y << " " << v.z << "\n";
+
+    obj << "\n# Faces\n";
+    for (const auto& f : hull) {
+        obj << "f " << indexMap[f.a] << " " << indexMap[f.b] << " " << indexMap[f.c] << "\n";
+    }
+
+    return obj.str();
+}
+
+}

--- a/src/cavise/sionna/bridge/meshes/PolyhedronMesh.cc
+++ b/src/cavise/sionna/bridge/meshes/PolyhedronMesh.cc
@@ -1,42 +1,33 @@
 #include <cavise/sionna/bridge/EnvironmentMeshGenerator.h>
+#include <cavise/sionna/bridge/Fwd.h>
+#include <cavise/sionna/bridge/Helpers.h>
 #include <cmath>
 #include <tuple>
 
+using Float = float;
+using Spectrum = mitsuba::Color<Float, 3>;
+
+namespace dr = drjit;
+
+MI_IMPORT_CORE_TYPES()
+
 namespace artery::sionna::meshes {
 
-struct Vec3 {
-    float x, y, z;
-    Vec3(float x = 0, float y = 0, float z = 0) : x(x), y(y), z(z) {}
-    Vec3 operator-(const Vec3& o) const { return {x - o.x, y - o.y, z - o.z}; }
-    Vec3 operator+(const Vec3& o) const { return {x + o.x, y + o.y, z + o.z}; }
-    Vec3 operator*(float s) const { return {x * s, y * s, z * s}; }
-    float dot(const Vec3& o) const { return x * o.x + y * o.y + z * o.z; }
-    Vec3 cross(const Vec3& o) const {
-        return {y * o.z - z * o.y, z * o.x - x * o.z, x * o.y - y * o.x};
-    }
-    float norm() const { return std::sqrt(x * x + y * y + z * z); }
-    Vec3 normalized() const {
-        float n = norm();
-        if (n < 1e-9f) return {0, 0, 0};
-        return {x / n, y / n, z / n};
-    }
-    bool operator==(const Vec3& o) const {
-        return std::abs(x - o.x) < 1e-6f && std::abs(y - o.y) < 1e-6f &&
-               std::abs(z - o.z) < 1e-6f;
-    }
-};
+Vector3f normalized(const Vector3f& p) {
+        float n = norm(p);
+        if (n < 1e-9f) return Vector3f(0.f);
+        return normalize(p);
+}
 
 // Centroid of a list of points
-Vec3 centroid(const std::vector<Vec3>& pts) {
-    Vec3 c;
+Vector3f centroid(const std::vector<Vector3f>& pts) {
+    Vector3f c(0.f);
     for (const auto& p : pts) {
-        c.x += p.x;
-        c.y += p.y;
-        c.z += p.z;
+        c += p;
     }
     float n = static_cast<float>(pts.size());
-    return {c.x / n, c.y / n, c.z / n};
-}
+    return c / n;
+};
 
 // ---------------------------------------------------------------------------
 // Minimal incremental convex hull (O(n^2)) for generateObjPolyhedron
@@ -45,53 +36,63 @@ Vec3 centroid(const std::vector<Vec3>& pts) {
 
 struct Face {
     int a, b, c;    // indices into the global point array
-    Vec3 normal;    // outward normal
+    Vector3f normal;    // outward normal
 };
 
 // Signed volume of tetrahedron formed by face (a,b,c) and point d
-float signedVolume(const Vec3& a, const Vec3& b, const Vec3& c, const Vec3& d) {
-    return (b - a).cross(c - a).dot(d - a);
+float signedVolume(const Vector3f& a, const Vector3f& b, const Vector3f& c, const Vector3f& d) {
+    return dot(cross(b - a, c - a), d - a);
 }
 
 // Returns true if point p is strictly above face (i.e. on the outward side)
-bool isVisible(const Face& f, const Vec3& p, const std::vector<Vec3>& pts) {
-    return f.normal.dot(p - pts[f.a]) > 1e-7f;
+bool isVisible(const Face& f, const Vector3f& p, const std::vector<Vector3f>& pts) {
+    return dot(f.normal, p - pts[f.a]) > 1e-7f;
 }
 
-std::vector<Face> buildConvexHull(const std::vector<Vec3>& pts) {
+std::vector<Face> buildConvexHull(const std::vector<Vector3f>& pts) {
     int n = static_cast<int>(pts.size());
-    assert(n >= 4 && "Need at least 4 non-coplanar points for a convex hull");
-
+    if (n < 4) {
+        throw wrapRuntimeError("Need at least 4 non-coplanar points for a convex hull");
+    }
     std::vector<Face> hull;
 
     // --- Build initial tetrahedron ---
     // Find 4 non-coplanar points
     int p0 = 0, p1 = -1, p2 = -1, p3 = -1;
 
-    for (int i = 1; i < n && p1 < 0; ++i)
-        if ((pts[i] - pts[p0]).norm() > 1e-7f)
+    for (int i = 1; i < n && p1 < 0; ++i) {
+        if (norm(pts[i] - pts[p0]) > 1e-7f) {
             p1 = i;
+        }
+    }
 
-    for (int i = 1; i < n && p2 < 0; ++i)
-        if (i != p1 && (pts[i] - pts[p0]).cross(pts[p1] - pts[p0]).norm() > 1e-7f)
+    for (int i = 1; i < n && p2 < 0; ++i) {
+        if (i != p1 && norm(cross(pts[i] - pts[p0], pts[p1] - pts[p0])) > 1e-7f) {
             p2 = i;
+        }
+    }
 
-    for (int i = 1; i < n && p3 < 0; ++i)
+    for (int i = 1; i < n && p3 < 0; ++i) {
         if (i != p1 && i != p2 &&
-            std::abs((pts[i] - pts[p0]).dot((pts[p1] - pts[p0]).cross(pts[p2] - pts[p0]))) > 1e-7f)
+            std::abs(dot(pts[i] - pts[p0], cross(pts[p1] - pts[p0], pts[p2] - pts[p0]))) > 1e-7f) {
             p3 = i;
+        }
+    }
 
-    assert(p1 >= 0 && p2 >= 0 && p3 >= 0 && "Points appear to be coplanar or collinear");
+    if (p1 < 0 || p2 < 0 || p3 < 0) {
+        throw wrapRuntimeError("Points appear to be coplanar or collinear");
+    }
 
     // Orient initial tetrahedron so all normals point outward
     // Use the centroid of the tetrahedron as the interior reference point
-    Vec3 innerPoint = (pts[p0] + pts[p1] + pts[p2] + pts[p3]) * 0.25f;
+    Vector3f innerPoint = (pts[p0] + pts[p1] + pts[p2] + pts[p3]) * 0.25f;
 
     auto makeFace = [&](int a, int b, int c) -> Face {
-        Vec3 n = (pts[b] - pts[a]).cross(pts[c] - pts[a]).normalized();
+        Vector3f n = normalized(cross(pts[b] - pts[a], pts[c] - pts[a]));
         // Flip if normal points inward
-        if (n.dot(pts[a] - innerPoint) < 0)
+        if (dot(n, pts[a] - innerPoint) < 0) {
             n = n * -1.0f, std::swap(b, c);
+        }
         return {a, b, c, n};
     };
 
@@ -102,10 +103,11 @@ std::vector<Face> buildConvexHull(const std::vector<Vec3>& pts) {
 
     // --- Incrementally add remaining points ---
     for (int i = 0; i < n; ++i) {
-        if (i == p0 || i == p1 || i == p2 || i == p3)
+        if (i == p0 || i == p1 || i == p2 || i == p3) {
             continue;
+        }
 
-        const Vec3& p = pts[i];
+        const Vector3f& p = pts[i];
 
         // Collect visible faces and horizon edges
         std::vector<bool> visible(hull.size(), false);
@@ -141,20 +143,23 @@ std::vector<Face> buildConvexHull(const std::vector<Vec3>& pts) {
                     }
                     if (adjVisible) break;
                 }
-                if (!adjVisible)
+                if (!adjVisible) {
                     horizon.push_back({ea, eb});
+                }
             }
         }
 
         // Remove visible faces
         std::vector<Face> newHull;
-        for (int f = 0; f < (int)hull.size(); ++f)
-            if (!visible[f])
+        for (int f = 0; f < (int)hull.size(); ++f) {
+            if (!visible[f]) {
                 newHull.push_back(hull[f]);
+            }
+        }
 
         // Add new cone faces from horizon edges to the new point
-        Vec3 innerPt = centroid([&]() {
-            std::vector<Vec3> tmp;
+        Vector3f innerPt = centroid([&]() {
+            std::vector<Vector3f> tmp;
             for (const auto& ff : newHull) {
                 tmp.push_back(pts[ff.a]);
                 tmp.push_back(pts[ff.b]);
@@ -164,9 +169,9 @@ std::vector<Face> buildConvexHull(const std::vector<Vec3>& pts) {
         }());
 
         for (const auto& e : horizon) {
-            Vec3 n = (pts[e.b] - pts[e.a]).cross(p - pts[e.a]).normalized();
+            Vector3f n = normalized(cross(pts[e.b] - pts[e.a], p - pts[e.a]));
             // Ensure outward orientation
-            if (n.dot(pts[e.a] - innerPt) < 0) {
+            if (dot(n, pts[e.a] - innerPt) < 0) {
                 n = n * -1.0f;
                 newHull.push_back({e.b, e.a, i, n});
             } else {
@@ -181,16 +186,21 @@ std::vector<Face> buildConvexHull(const std::vector<Vec3>& pts) {
 }
 
 std::string generateObjPolyhedron(const std::vector<float>& vertices) {
-    assert(vertices.size() % 3 == 0 && "vertices must contain x,y,z triples");
-    assert(vertices.size() >= 12 && "Need at least 4 points for a polyhedron");
+    if (vertices.size() % 3 != 0) {
+        throw wrapRuntimeError("vertices must contain x,y,z triples");
+    }
+    if (vertices.size() < 12) {
+        throw wrapRuntimeError("Need at least 4 points for a polyhedron");
+    }
 
     const int n = static_cast<int>(vertices.size()) / 3;
 
-    // Build Vec3 point list
-    std::vector<Vec3> pts;
+    // Build Vector3f point list
+    std::vector<Vector3f> pts;
     pts.reserve(n);
-    for (int i = 0; i < n; ++i)
+    for (int i = 0; i < n; ++i) {
         pts.push_back({vertices[3 * i], vertices[3 * i + 1], vertices[3 * i + 2]});
+    }
 
     // Compute convex hull
     std::vector<Face> hull = buildConvexHull(pts);
@@ -199,7 +209,7 @@ std::string generateObjPolyhedron(const std::vector<float>& vertices) {
     // Build deduplicated vertex list for the OBJ output.
     // We collect only the hull vertices (some input points may be interior).
     // -----------------------------------------------------------------------
-    std::vector<Vec3> outVerts;
+    std::vector<Vector3f> outVerts;
     // Map from original index -> output index (1-based)
     std::unordered_map<int, int> indexMap;
 
@@ -223,8 +233,9 @@ std::string generateObjPolyhedron(const std::vector<float>& vertices) {
     obj << "o Polyhedron\n\n";
 
     // Vertices
-    for (const auto& v : outVerts)
-        obj << "v " << v.x << " " << v.y << " " << v.z << "\n";
+    for (const auto& v : outVerts) {
+        obj << "v " << v.x() << " " << v.y() << " " << v.z() << "\n";
+    }
 
     obj << "\n# Faces\n";
     for (const auto& f : hull) {

--- a/src/cavise/sionna/bridge/meshes/PolyhedronMesh.cc
+++ b/src/cavise/sionna/bridge/meshes/PolyhedronMesh.cc
@@ -1,28 +1,22 @@
 #include <cavise/sionna/bridge/EnvironmentMeshGenerator.h>
 #include <cavise/sionna/bridge/Fwd.h>
+#include <cavise/sionna/bridge/Compat.h>
 #include <cavise/sionna/bridge/Helpers.h>
 #include <cmath>
 
-using Float = float;
-using Spectrum = mitsuba::Color<Float, 3>;
-
-namespace dr = drjit;
-
-MI_IMPORT_CORE_TYPES()
-
 namespace artery::sionna::meshes {
 
-Vector3f normalized(const Vector3f& p) {
-        float n = norm(p);
+mitsuba::Resolve::Vector3f normalized(const mitsuba::Resolve::Vector3f& p) {
+        float n = toScalar(norm(p));
         if (n < 1e-9F) {
-            return Vector3f(0.F);
+            return mitsuba::Resolve::Vector3f(0.F);
         }
         return normalize(p);
 }
 
 // Centroid of a list of points
-Vector3f centroid(const std::vector<Vector3f>& pts) {
-    Vector3f c(0.F);
+mitsuba::Resolve::Vector3f centroid(const std::vector<mitsuba::Resolve::Vector3f>& pts) {
+    mitsuba::Resolve::Vector3f c(0.F);
     for (const auto& p : pts) {
         c += p;
     }
@@ -37,20 +31,15 @@ Vector3f centroid(const std::vector<Vector3f>& pts) {
 
 struct Face {
     int a{}, b{}, c{}; // indices into the global point array
-    Vector3f normal{}; // outward normal
+    mitsuba::Resolve::Vector3f normal{}; // outward normal
 };
 
-// Signed volume of tetrahedron formed by face (a,b,c) and point d
-float signedVolume(const Vector3f& a, const Vector3f& b, const Vector3f& c, const Vector3f& d) {
-    return dot(cross(b - a, c - a), d - a);
-}
-
 // Returns true if point p is strictly above face (i.e. on the outward side)
-bool isVisible(const Face& f, const Vector3f& p, const std::vector<Vector3f>& pts) {
-    return dot(f.normal, p - pts[f.a]) > 1e-7F;
+bool isVisible(const Face& f, const mitsuba::Resolve::Vector3f& p, const std::vector<mitsuba::Resolve::Vector3f>& pts) {
+    return toScalar(dot(f.normal, p - pts[f.a])) > 1e-7F;
 }
 
-std::vector<Face> buildConvexHull(const std::vector<Vector3f>& pts) {
+std::vector<Face> buildConvexHull(const std::vector<mitsuba::Resolve::Vector3f>& pts) {
     int n = static_cast<int>(pts.size());
     if (n < 4) {
         throw wrapRuntimeError("Need at least 4 non-coplanar points for a convex hull");
@@ -65,20 +54,20 @@ std::vector<Face> buildConvexHull(const std::vector<Vector3f>& pts) {
     int p3 = -1;
 
     for (int i = 1; i < n && p1 < 0; ++i) {
-        if (norm(pts[i] - pts[p0]) > 1e-7F) {
+        if (toScalar(norm(pts[i] - pts[p0])) > 1e-7F) {
             p1 = i;
         }
     }
 
     for (int i = 1; i < n && p2 < 0; ++i) {
-        if (i != p1 && norm(cross(pts[i] - pts[p0], pts[p1] - pts[p0])) > 1e-7F) {
+        if (i != p1 && toScalar(norm(cross(pts[i] - pts[p0], pts[p1] - pts[p0]))) > 1e-7F) {
             p2 = i;
         }
     }
 
     for (int i = 1; i < n && p3 < 0; ++i) {
         if (i != p1 && i != p2 &&
-            std::abs(dot(pts[i] - pts[p0], cross(pts[p1] - pts[p0], pts[p2] - pts[p0]))) > 1e-7F) {
+            std::abs(toScalar(dot(pts[i] - pts[p0], cross(pts[p1] - pts[p0], pts[p2] - pts[p0])))) > 1e-7F) {
             p3 = i;
         }
     }
@@ -89,12 +78,12 @@ std::vector<Face> buildConvexHull(const std::vector<Vector3f>& pts) {
 
     // Orient initial tetrahedron so all normals point outward
     // Use the centroid of the tetrahedron as the interior reference point
-    Vector3f innerPoint = (pts[p0] + pts[p1] + pts[p2] + pts[p3]) * 0.25F;
+    mitsuba::Resolve::Vector3f innerPoint = (pts[p0] + pts[p1] + pts[p2] + pts[p3]) * 0.25F;
 
     auto makeFace = [&](int a, int b, int c) -> Face {
-        Vector3f n = normalized(cross(pts[b] - pts[a], pts[c] - pts[a]));
+        mitsuba::Resolve::Vector3f n = normalized(cross(pts[b] - pts[a], pts[c] - pts[a]));
         // Flip if normal points inward
-        if (dot(n, pts[a] - innerPoint) < 0) {
+        if (toScalar(dot(n, pts[a] - innerPoint)) < 0) {
             n = n * -1.0F, std::swap(b, c);
         }
         return {a, b, c, n};
@@ -111,7 +100,7 @@ std::vector<Face> buildConvexHull(const std::vector<Vector3f>& pts) {
             continue;
         }
 
-        const Vector3f& p = pts[i];
+        const mitsuba::Resolve::Vector3f& p = pts[i];
 
         // Collect visible faces and horizon edges
         std::vector<bool> visible(hull.size(), false);
@@ -173,8 +162,8 @@ std::vector<Face> buildConvexHull(const std::vector<Vector3f>& pts) {
         }
 
         // Add new cone faces from horizon edges to the new point
-        Vector3f innerPt = centroid([&]() {
-            std::vector<Vector3f> tmp;
+        mitsuba::Resolve::Vector3f innerPt = centroid([&]() {
+            std::vector<mitsuba::Resolve::Vector3f> tmp;
             for (const auto& ff : newHull) {
                 tmp.push_back(pts[ff.a]);
                 tmp.push_back(pts[ff.b]);
@@ -184,9 +173,9 @@ std::vector<Face> buildConvexHull(const std::vector<Vector3f>& pts) {
         }());
 
         for (const auto& e : horizon) {
-            Vector3f n = normalized(cross(pts[e.b] - pts[e.a], p - pts[e.a]));
+            mitsuba::Resolve::Vector3f n = normalized(cross(pts[e.b] - pts[e.a], p - pts[e.a]));
             // Ensure outward orientation
-            if (dot(n, pts[e.a] - innerPt) < 0) {
+            if (toScalar(dot(n, pts[e.a] - innerPt)) < 0) {
                 n = n * -1.0F;
                 newHull.push_back({e.b, e.a, i, n});
             } else {
@@ -211,7 +200,7 @@ std::string generateObjPolyhedron(const std::vector<float>& vertices) {
     const int n = static_cast<int>(vertices.size()) / 3;
 
     // Build Vector3f point list
-    std::vector<Vector3f> pts;
+    std::vector<mitsuba::Resolve::Vector3f> pts;
     pts.reserve(n);
     for (int i = 0; i < n; ++i) {
         pts.push_back({vertices[3 * i], vertices[3 * i + 1], vertices[3 * i + 2]});
@@ -224,7 +213,7 @@ std::string generateObjPolyhedron(const std::vector<float>& vertices) {
     // Build deduplicated vertex list for the OBJ output.
     // We collect only the hull vertices (some input points may be interior).
     // -----------------------------------------------------------------------
-    std::vector<Vector3f> outVerts;
+    std::vector<mitsuba::Resolve::Vector3f> outVerts;
     // Map from original index -> output index (1-based)
     std::unordered_map<int, int> indexMap;
 

--- a/src/cavise/sionna/bridge/meshes/PrismMesh.cc
+++ b/src/cavise/sionna/bridge/meshes/PrismMesh.cc
@@ -1,0 +1,62 @@
+#include <cavise/sionna/bridge/EnvironmentMeshGenerator.h>
+
+namespace artery::sionna::meshes {
+
+std::string generateObjPrism(float height, const std::vector<float>& vertices) {
+    const int n = static_cast<int>(vertices.size()) / 2; // number of base polygon points
+
+    std::ostringstream obj;
+    obj << "o Prism\n";
+
+    // -----------------------------------------------------------------------
+    // Vertices
+    // Bottom ring (z = 0): indices 1..n
+    // Top ring    (z = h): indices n+1..2n
+    // -----------------------------------------------------------------------
+    obj << "# Bottom ring (z = 0)\n"; // Debug
+    for (int i = 0; i < n; ++i)
+        obj << "v " << vertices[2 * i] << " " << vertices[2 * i + 1] << " 0\n";
+
+    obj << "\n# Top ring (z = " << height << ")\n"; // Debug
+    for (int i = 0; i < n; ++i)
+        obj << "v " << vertices[2 * i] << " " << vertices[2 * i + 1] << " " << height << "\n";
+
+    obj << "\n";
+
+    // OBJ indices are 1-based
+    // Bottom ring: vertex i   -> OBJ index (i+1)
+    // Top ring:    vertex i   -> OBJ index (n + i + 1)
+
+    // -----------------------------------------------------------------------
+    // Bottom face (fan triangulation, reversed winding for downward normal)
+    // -----------------------------------------------------------------------
+    obj << "# Bottom face\n";
+    for (int i = 1; i < n - 1; ++i)
+        obj << "f " << 1 << " " << (i + 2) << " " << (i + 1) << "\n";
+
+    // -----------------------------------------------------------------------
+    // Top face (fan triangulation, normal upward)
+    // -----------------------------------------------------------------------
+    obj << "\n# Top face\n";
+    for (int i = 1; i < n - 1; ++i)
+        obj << "f " << (n + 1) << " " << (n + i + 1) << " " << (n + i + 2) << "\n";
+
+    // -----------------------------------------------------------------------
+    // Side faces (quads split into two triangles per edge of the base polygon)
+    // -----------------------------------------------------------------------
+    obj << "\n# Side faces\n";
+    for (int i = 0; i < n; ++i) {
+        int bot0 = i + 1;          // OBJ index, bottom vertex i
+        int bot1 = (i + 1) % n + 1; // OBJ index, bottom vertex i+1
+        int top0 = n + i + 1;      // OBJ index, top vertex i
+        int top1 = n + (i + 1) % n + 1; // OBJ index, top vertex i+1
+
+        // Two triangles per quad, outward normals
+        obj << "f " << bot0 << " " << bot1 << " " << top1 << "\n";
+        obj << "f " << bot0 << " " << top1 << " " << top0 << "\n";
+    }
+
+    return obj.str();
+}
+
+}

--- a/src/cavise/sionna/bridge/meshes/SphereMesh.cc
+++ b/src/cavise/sionna/bridge/meshes/SphereMesh.cc
@@ -6,12 +6,13 @@ std::string generateObjSphere(float radius) {
     std::ostringstream oss;
     oss << "o Sphere\n";
     
-    const int rings = 16, sectors = 32;
+    const int rings = 16;
+    const int sectors = 32;
     
     for (int r = 0; r <= rings; ++r) {
         float phi = M_PI * r / rings;
         for (int s = 0; s <= sectors; ++s) {
-            float theta = 2.0f * M_PI * s / sectors;
+            float theta = 2.0F * M_PI * s / sectors;
             float x = radius * sinf(phi) * cosf(theta);
             float y = radius * sinf(phi) * sinf(theta);
             float z = radius * cosf(phi);

--- a/src/cavise/sionna/bridge/meshes/SphereMesh.cc
+++ b/src/cavise/sionna/bridge/meshes/SphereMesh.cc
@@ -1,0 +1,34 @@
+#include <cavise/sionna/bridge/EnvironmentMeshGenerator.h>
+
+namespace artery::sionna::meshes {
+
+std::string generateObjSphere(float radius) {
+    std::ostringstream oss;
+    oss << "o Sphere\n";
+    
+    const int rings = 16, sectors = 32;
+    
+    for (int r = 0; r <= rings; ++r) {
+        float phi = M_PI * r / rings;
+        for (int s = 0; s <= sectors; ++s) {
+            float theta = 2.0f * M_PI * s / sectors;
+            float x = radius * sinf(phi) * cosf(theta);
+            float y = radius * sinf(phi) * sinf(theta);
+            float z = radius * cosf(phi);
+            oss << "v " << x << " " << y << " " << z << "\n";
+        }
+    }
+    
+    for (int r = 0; r < rings; ++r) {
+        for (int s = 0; s < sectors; ++s) {
+            int i0 = r * (sectors + 1) + s;
+            int i1 = i0 + sectors + 1;
+            oss << "f " << i0+1 << " " << i1+1 << " " << (i1+1)+1 << "\n";
+            oss << "f " << i0+1 << " " << (i1+1)+1 << " " << (i0+1)+1 << "\n";
+        }
+    }
+    
+    return oss.str();
+}
+
+}

--- a/src/cavise/sionna/tests/TestMitsubaLikesShapes.cc
+++ b/src/cavise/sionna/tests/TestMitsubaLikesShapes.cc
@@ -68,12 +68,12 @@ protected:
 // ============================================================================
 
 TEST_F(SceneTest, Cube_Unit) {
-    std::string obj = artery::sionna::meshes::generateObjCube(1.0f, 1.0f, 1.0f);
+    std::string const obj = artery::sionna::meshes::generateObjCube(1.0F, 1.0F, 1.0F);
     SaveObjToFile(obj, "cube_unit.obj");
 }
 
 TEST_F(SceneTest, Cube_Rectangular) {
-    std::string obj = artery::sionna::meshes::generateObjCube(10.0f, 5.0f, 2.0f);
+    std::string const obj = artery::sionna::meshes::generateObjCube(10.0F, 5.0F, 2.0F);
     SaveObjToFile(obj, "cube_rect.obj");
 }
 
@@ -82,12 +82,12 @@ TEST_F(SceneTest, Cube_Rectangular) {
 // ============================================================================
 
 TEST_F(SceneTest, Sphere_Radius1) {
-    std::string obj = artery::sionna::meshes::generateObjSphere(1.0f);
+    std::string const obj = artery::sionna::meshes::generateObjSphere(1.0F);
     SaveObjToFile(obj, "sphere_r1.obj");
 }
 
 TEST_F(SceneTest, Sphere_Radius10) {
-    std::string obj = artery::sionna::meshes::generateObjSphere(10.0f);
+    std::string const obj = artery::sionna::meshes::generateObjSphere(10.0F);
     SaveObjToFile(obj, "sphere_r10.obj");
 }
 
@@ -190,8 +190,9 @@ TEST_F(SceneTest, Render_Simple_xml) {
 
     // Set up FileResolver like the old parser does
     fs::path filename(name);
-    if (!fs::exists(filename))
+    if (!fs::exists(filename)) {
         Throw("\"%s\": file does not exist!", filename);
+    }
 
     ref<FileResolver> fs_backup = file_resolver(); // better to prepare new file_resolver to avoid conflicts
     ref<FileResolver> fs = new FileResolver(*fs_backup);
@@ -200,7 +201,7 @@ TEST_F(SceneTest, Render_Simple_xml) {
 
     std::vector<ref<Object>> objects;
     try {
-        nb::gil_scoped_release release;
+        nb::gil_scoped_release const release;
         parser::ParserState state = parser::parse_file(config, name, params);
         parser::transform_all(config, state);
         objects = parser::instantiate(config, state);

--- a/src/cavise/sionna/tests/TestMitsubaLikesShapes.cc
+++ b/src/cavise/sionna/tests/TestMitsubaLikesShapes.cc
@@ -99,8 +99,8 @@ TEST_F(SceneTest, Prism_Hexagon) {
     // INET: shape="prism 100 -86.6 -50 0 -100 86.6 -50 86.6 50 0 100 -86.6 50"
     float const height = 100.0F;
     std::vector<float> base = {
-        -86.6f, -50.0f,  0.0f, -100.0f,  86.6f, -50.0f,
-         86.6f,  50.0f,  0.0f,  100.0f, -86.6f,  50.0f
+        -86.6F, -50.0F,  0.0F, -100.0F,  86.6F, -50.0F,
+         86.6F,  50.0F,  0.0F,  100.0F, -86.6F,  50.0F
     };
 
     std::string obj = artery::sionna::meshes::generateObjPrism(height, base);
@@ -110,7 +110,7 @@ TEST_F(SceneTest, Prism_Hexagon) {
 TEST_F(SceneTest, Prism_Triangle) {
     // INET: shape="prism 100 0 0 150 0 75 129.9"
     float const height = 100.0F;
-    std::vector<float> base = {0.0f, 0.0f, 150.0f, 0.0f, 75.0f, 129.9f};
+    std::vector<float> base = {0.0F, 0.0F, 150.0F, 0.0F, 75.0F, 129.9F};
 
     std::string obj = artery::sionna::meshes::generateObjPrism(height, base);
     SaveObjToFile(obj, "prism_tri.obj");
@@ -213,7 +213,7 @@ TEST_F(SceneTest, Render_Simple_xml) {
     
     //MI_INVOKE_VARIANT(variant_str.c_str(), render, objects[0].get(), sensor_i, filename);
     auto *scene = dynamic_cast<Scene<Float, Spectrum> *>(objects[0].get());
-    if (!scene) {
+    if (scene == nullptr) {
         Throw("Root element of the input file must be a <scene> tag!");
     }
     if (scene->sensors().empty()) {
@@ -225,7 +225,7 @@ TEST_F(SceneTest, Render_Simple_xml) {
     auto film = scene->sensors()[sensor_i]->film();
 
     auto integrator = scene->integrator();
-    if (!integrator) {
+    if (integrator == nullptr) {
         Throw("No integrator specified for scene: %s", scene);
     }
 

--- a/src/cavise/sionna/tests/TestMitsubaLikesShapes.cc
+++ b/src/cavise/sionna/tests/TestMitsubaLikesShapes.cc
@@ -112,7 +112,7 @@ TEST_F(SceneTest, Prism_Triangle) {
 }
 
 TEST_F(SceneTest, Prism_Quad) {
-    // Прямоугольная призма (кубоид через prism)
+    // INET: shape="prism 10 -5 -5 5 -5 5 5 -5 5"
     float height = 10.0f;
     std::vector<float> base = {-5, -5, 5, -5, 5, 5, -5, 5};
 

--- a/src/cavise/sionna/tests/TestMitsubaLikesShapes.cc
+++ b/src/cavise/sionna/tests/TestMitsubaLikesShapes.cc
@@ -1,6 +1,9 @@
-#include <memory>
+#include <functional>
+#include <ios>
+#include <iostream>
+#include <cstddef>
+#include <cstdint>
 #include <fstream>
-#include <optional>
 #include <filesystem>
 
 #include <gtest/gtest.h>
@@ -27,13 +30,15 @@
 #include <nanobind/stl/bind_vector.h>
 
 #include <cavise/sionna/bridge/EnvironmentMeshGenerator.h>
+#include <string>
 
 namespace nb = nanobind;
 
 static std::function<void()> develop_callback_fn = nullptr;
 static void develop_callback() {
-    if (develop_callback_fn)
+    if (develop_callback_fn) {
         develop_callback_fn();
+    }
 }
 
 class SceneTest : public ::testing::Test {
@@ -46,14 +51,14 @@ protected:
         std::filesystem::path filepath = std::filesystem::path("meshes") / filename;
         
         std::ofstream out(filepath, std::ios::trunc);
-        ASSERT_TRUE(out.is_open()) << "Failed to open file: " << filepath;
-        
+        ASSERT_TRUE(out.is_open()) << true << filepath;
+
         out << obj_content;
         out.close();
-        
-        EXPECT_TRUE(std::filesystem::exists(filepath)) << "Output file was not created: " << filepath;
-        EXPECT_GT(std::filesystem::file_size(filepath), 0) << "Output file is empty: " << filepath;
-        
+
+        EXPECT_TRUE(std::filesystem::exists(filepath)) << true << filepath;
+        EXPECT_GT(std::filesystem::file_size(filepath), 0) << true << filepath;
+
         std::cout << "Saved: " << filepath << " (" << std::filesystem::file_size(filepath) << " bytes)\n";
     }
 };
@@ -92,7 +97,7 @@ TEST_F(SceneTest, Sphere_Radius10) {
 
 TEST_F(SceneTest, Prism_Hexagon) {
     // INET: shape="prism 100 -86.6 -50 0 -100 86.6 -50 86.6 50 0 100 -86.6 50"
-    float height = 100.0f;
+    float const height = 100.0F;
     std::vector<float> base = {
         -86.6f, -50.0f,  0.0f, -100.0f,  86.6f, -50.0f,
          86.6f,  50.0f,  0.0f,  100.0f, -86.6f,  50.0f
@@ -104,7 +109,7 @@ TEST_F(SceneTest, Prism_Hexagon) {
 
 TEST_F(SceneTest, Prism_Triangle) {
     // INET: shape="prism 100 0 0 150 0 75 129.9"
-    float height = 100.0f;
+    float const height = 100.0F;
     std::vector<float> base = {0.0f, 0.0f, 150.0f, 0.0f, 75.0f, 129.9f};
 
     std::string obj = artery::sionna::meshes::generateObjPrism(height, base);
@@ -113,7 +118,7 @@ TEST_F(SceneTest, Prism_Triangle) {
 
 TEST_F(SceneTest, Prism_Quad) {
     // INET: shape="prism 10 -5 -5 5 -5 5 5 -5 5"
-    float height = 10.0f;
+    float const height = 10.0F;
     std::vector<float> base = {-5, -5, 5, -5, 5, 5, -5, 5};
 
     std::string obj = artery::sionna::meshes::generateObjPrism(height, base);
@@ -161,8 +166,8 @@ TEST_F(SceneTest, Render_Simple_xml) {
 
     ASSERT_EQ(MI_DEFAULT_VARIANT, "scalar_rgb");
 
-    bool parallel{true}; // Common flags
-    bool optimize{true};
+    bool const parallel{true}; // Common flags
+    bool const optimize{true};
     std::string name{"./simple.xml"}; // Relative path !!!PREPARE SCENE AND MESHES
     std::string name_out{"./simple.exr"};
 
@@ -170,8 +175,9 @@ TEST_F(SceneTest, Render_Simple_xml) {
     mi.attr("set_variant")(MI_DEFAULT_VARIANT); // curr_variant hiden inside library, can't change without memory fuckery. Too dangerous to change via callback, but possible, check alias.cpp:162
 
     nb::object variant = mi.attr("variant")(); // Verification + posible expansion of variants to test
-    if (variant.is_none())
+    if (variant.is_none()) {
         Throw("No variant was set!");
+    }
 
     parser::ParameterList params; // maybe params.reserve(0) ???
     nb::str variant_str = nb::borrow<nb::str>(std::move(variant));
@@ -206,17 +212,21 @@ TEST_F(SceneTest, Render_Simple_xml) {
     
     //MI_INVOKE_VARIANT(variant_str.c_str(), render, objects[0].get(), sensor_i, filename);
     auto *scene = dynamic_cast<Scene<Float, Spectrum> *>(objects[0].get());
-    if (!scene)
+    if (!scene) {
         Throw("Root element of the input file must be a <scene> tag!");
-    if (scene->sensors().empty())
+    }
+    if (scene->sensors().empty()) {
         Throw("No sensor specified for scene: %s", scene);
-    if (sensor_i >= scene->sensors().size())
+    }
+    if (sensor_i >= scene->sensors().size()) {
         Throw("Specified sensor index is out of bounds!");
+    }
     auto film = scene->sensors()[sensor_i]->film();
 
     auto integrator = scene->integrator();
-    if (!integrator)
+    if (!integrator) {
         Throw("No integrator specified for scene: %s", scene);
+    }
 
     develop_callback_fn = [film]() { film->develop(); };
 

--- a/src/cavise/sionna/tests/TestMitsubaLikesShapes.cc
+++ b/src/cavise/sionna/tests/TestMitsubaLikesShapes.cc
@@ -26,6 +26,8 @@
 #include <nanobind/stl/pair.h>
 #include <nanobind/stl/bind_vector.h>
 
+#include <cavise/sionna/bridge/EnvironmentMeshGenerator.h>
+
 namespace nb = nanobind;
 
 static std::function<void()> develop_callback_fn = nullptr;
@@ -34,7 +36,123 @@ static void develop_callback() {
         develop_callback_fn();
 }
 
-TEST(SceneTest, Scalar_RGB) {
+class SceneTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        std::filesystem::create_directories("meshes");
+    }
+
+    static void SaveObjToFile(const std::string& obj_content, const std::string& filename) {
+        std::filesystem::path filepath = std::filesystem::path("meshes") / filename;
+        
+        std::ofstream out(filepath, std::ios::trunc);
+        ASSERT_TRUE(out.is_open()) << "Failed to open file: " << filepath;
+        
+        out << obj_content;
+        out.close();
+        
+        EXPECT_TRUE(std::filesystem::exists(filepath)) << "Output file was not created: " << filepath;
+        EXPECT_GT(std::filesystem::file_size(filepath), 0) << "Output file is empty: " << filepath;
+        
+        std::cout << "Saved: " << filepath << " (" << std::filesystem::file_size(filepath) << " bytes)\n";
+    }
+};
+
+// ============================================================================
+// CUBE TESTS
+// ============================================================================
+
+TEST_F(SceneTest, Cube_Unit) {
+    std::string obj = artery::sionna::meshes::generateObjCube(1.0f, 1.0f, 1.0f);
+    SaveObjToFile(obj, "cube_unit.obj");
+}
+
+TEST_F(SceneTest, Cube_Rectangular) {
+    std::string obj = artery::sionna::meshes::generateObjCube(10.0f, 5.0f, 2.0f);
+    SaveObjToFile(obj, "cube_rect.obj");
+}
+
+// ============================================================================
+// SPHERE TESTS
+// ============================================================================
+
+TEST_F(SceneTest, Sphere_Radius1) {
+    std::string obj = artery::sionna::meshes::generateObjSphere(1.0f);
+    SaveObjToFile(obj, "sphere_r1.obj");
+}
+
+TEST_F(SceneTest, Sphere_Radius10) {
+    std::string obj = artery::sionna::meshes::generateObjSphere(10.0f);
+    SaveObjToFile(obj, "sphere_r10.obj");
+}
+
+// ============================================================================
+// PRISM TESTS
+// ============================================================================
+
+TEST_F(SceneTest, Prism_Hexagon) {
+    // INET: shape="prism 100 -86.6 -50 0 -100 86.6 -50 86.6 50 0 100 -86.6 50"
+    float height = 100.0f;
+    std::vector<float> base = {
+        -86.6f, -50.0f,  0.0f, -100.0f,  86.6f, -50.0f,
+         86.6f,  50.0f,  0.0f,  100.0f, -86.6f,  50.0f
+    };
+
+    std::string obj = artery::sionna::meshes::generateObjPrism(height, base);
+    SaveObjToFile(obj, "prism_hex.obj");
+}
+
+TEST_F(SceneTest, Prism_Triangle) {
+    // INET: shape="prism 100 0 0 150 0 75 129.9"
+    float height = 100.0f;
+    std::vector<float> base = {0.0f, 0.0f, 150.0f, 0.0f, 75.0f, 129.9f};
+
+    std::string obj = artery::sionna::meshes::generateObjPrism(height, base);
+    SaveObjToFile(obj, "prism_tri.obj");
+}
+
+TEST_F(SceneTest, Prism_Quad) {
+    // Прямоугольная призма (кубоид через prism)
+    float height = 10.0f;
+    std::vector<float> base = {-5, -5, 5, -5, 5, 5, -5, 5};
+
+    std::string obj = artery::sionna::meshes::generateObjPrism(height, base);
+    SaveObjToFile(obj, "prism_quad.obj");
+}
+
+// ============================================================================
+// POLYHEDRON TESTS
+// ============================================================================
+
+TEST_F(SceneTest, Polyhedron_Cube8Vertices) {
+    std::vector<float> verts = {
+        0,0,0, 100,0,0, 0,0,100, 100,0,100,
+        0,100,0, 100,100,0, 0,100,100, 100,100,100
+    };
+
+    std::string obj = artery::sionna::meshes::generateObjPolyhedron(verts);
+    SaveObjToFile(obj, "polyhedron_cube.obj");
+}
+
+TEST_F(SceneTest, Polyhedron_Tetrahedron) {
+    std::vector<float> verts = {
+        0,100,100, 100,100,0, 0,0,0, 100,0,100
+    };
+
+    std::string obj = artery::sionna::meshes::generateObjPolyhedron(verts);
+    SaveObjToFile(obj, "polyhedron_tetra.obj");
+}
+
+TEST_F(SceneTest, Polyhedron_Pyramid) {
+    std::vector<float> verts = {
+        0,0,0, 100,0,0, 0,0,100, 100,0,100, 50,250,50
+    };
+
+    std::string obj = artery::sionna::meshes::generateObjPolyhedron(verts);
+    SaveObjToFile(obj, "polyhedron_pyramid.obj");
+}
+
+TEST_F(SceneTest, Render_Simple_xml) {
     using Float = float;
     using Spectrum = mitsuba::Color<Float, 3>;
 


### PR DESCRIPTION
Added the feature to convert all inet shapes into objects (.obj). These files are compatible for import into Mitsuba scenes and will be used to generate configurations based on the inet's obstacles.xml file.
Modified the corresponding test to verify the validity of the relevant shapes.



<img width="882" height="650" alt="image" src="https://github.com/user-attachments/assets/4d796482-60f4-4e83-a6b8-b84bad2fe3be" />
<img width="782" height="562" alt="image" src="https://github.com/user-attachments/assets/5e7b576b-aea1-4fef-8cd7-dfe73292b613" />
