### PR TITLE
[Sionna] Enable python callbacks for sionna renders

### DIFF
--- a/scenarios/sionna/omnetpp.ini
+++ b/scenarios/sionna/omnetpp.ini
@@ -50,5 +50,7 @@ cmdenv-output-file = ".cmdenv-log"
 *.physicalEnvironment.sceneVisualizer.width = 1280
 *.physicalEnvironment.sceneVisualizer.height = 720
 
+*.physicalEnvironment.sceneVisualizer.pythonRenderer = "scripts/example_renderer.py:render_callback"
+
 [Config sumo_gui]
 *.traci.launcher.sumo = "sumo-gui"

--- a/scenarios/sionna/scripts/example_renderer.py
+++ b/scenarios/sionna/scripts/example_renderer.py
@@ -1,0 +1,117 @@
+"""
+Example custom renderer callback for SionnaSceneVisualizer.
+
+This module demonstrates how to create a custom Python renderer callback
+that can be used with the SionnaSceneVisualizer's pythonRenderer parameter.
+
+Usage in omnetpp.ini:
+    *.physicalEnvironment.sceneVisualizer.pythonRenderer = "scenarios.sionna.scripts.example_renderer.render_callback"
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import mitsuba as mi
+import numpy as np
+import sionna.rt as rt
+
+
+def render_callback(scene, sim_time, output_dir, frame_index):
+    """
+    Custom render callback for SionnaSceneVisualizer.
+
+    Parameters:
+    -----------
+    scene : sionna.rt.Scene
+        The Sionna scene object to render
+    sim_time : float
+        Current simulation time in seconds
+    output_dir : str
+        Output directory path for rendered frames
+    frame_index : int
+        Current frame index
+
+    Returns:
+    --------
+    None
+    """
+
+    # Create output directory if it doesn't exist
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    # Example: Create a camera with custom settings
+    # You can dynamically adjust camera based on simulation time
+    camera = rt.Camera(
+        position=mi.Point3f(0.0, 0.0, 150.0),
+        orientation=mi.Point3f(0.0, 0.0, 0.0),
+    )
+
+    # Example: Adjust rendering parameters based on simulation time
+    # This demonstrates the flexibility of using Python callbacks
+    if sim_time < 10.0:
+        num_samples = 32
+        resolution = (1280, 720)
+    else:
+        num_samples = 64
+        resolution = (1920, 1080)
+
+    # Example: Add an environment map for lighting (optional)
+    # envmap_path = "/path/to/envmap.exr"
+    envmap = None  # Set to a path if you have an envmap
+
+    # Render to file
+    filename = output_path / f"frame_{frame_index:06d}.png"
+
+    scene.render_to_file(
+        camera=camera,
+        filename=str(filename),
+        num_samples=num_samples,
+        resolution=resolution,
+        fov=45.0,
+        envmap=envmap,
+        lighting_scale=1.0
+    )
+
+    print(f"Rendered frame {frame_index} at sim_time {sim_time:.2f}s to {filename}")
+
+
+def render_callback_with_multiple_cameras(scene, sim_time, output_dir, frame_index):
+    """
+    Example callback that renders from multiple camera angles.
+
+    This demonstrates how you can render multiple views in a single callback.
+    """
+
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    # Define multiple camera positions
+    cameras = [
+        ("front", mi.Point3f(0.0, -100.0, 50.0), mi.Point3f(0.0, 0.1, 0.0)),
+        ("top", mi.Point3f(0.0, 0.0, 200.0), mi.Point3f(0.0, 0.0, 0.0)),
+        ("side", mi.Point3f(100.0, 0.0, 50.0), mi.Point3f(-0.1, 0.0, 0.0)),
+    ]
+
+    for cam_name, position, orientation in cameras:
+        camera = rt.Camera(
+            position=position,
+            orientation=orientation,
+        )
+
+        # Create subdirectory for each camera
+        cam_dir = output_path / cam_name
+        cam_dir.mkdir(exist_ok=True)
+
+        filename = cam_dir / f"frame_{frame_index:06d}.png"
+
+        scene.render_to_file(
+            camera=camera,
+            filename=str(filename),
+            num_samples=32,
+            resolution=(1280, 720),
+            fov=45.0,
+        )
+
+    print(f"Rendered frame {frame_index} from {len(cameras)} camera angles")

--- a/scenarios/sionna/scripts/example_renderer.py
+++ b/scenarios/sionna/scripts/example_renderer.py
@@ -5,7 +5,7 @@ This module demonstrates how to create a custom Python renderer callback
 that can be used with the SionnaSceneVisualizer's pythonRenderer parameter.
 
 Usage in omnetpp.ini:
-    *.physicalEnvironment.sceneVisualizer.pythonRenderer = "scenarios.sionna.scripts.example_renderer.render_callback"
+    *.physicalEnvironment.sceneVisualizer.pythonRenderer = "scenarios/sionna/scripts/example_renderer.py:render_callback"
 """
 
 import os

--- a/scenarios/sionna/scripts/example_renderer.py
+++ b/scenarios/sionna/scripts/example_renderer.py
@@ -5,7 +5,7 @@ This module demonstrates how to create a custom Python renderer callback
 that can be used with the SionnaSceneVisualizer's pythonRenderer parameter.
 
 Usage in omnetpp.ini:
-    *.physicalEnvironment.sceneVisualizer.pythonRenderer = "scenarios/sionna/scripts/example_renderer.py:render_callback"
+    *.physicalEnvironment.sceneVisualizer.pythonRenderer = "scripts/example_renderer.py:render_callback"
 """
 
 import os
@@ -18,25 +18,6 @@ import sionna.rt as rt
 
 
 def render_callback(scene, sim_time, output_dir, frame_index):
-    """
-    Custom render callback for SionnaSceneVisualizer.
-
-    Parameters:
-    -----------
-    scene : sionna.rt.Scene
-        The Sionna scene object to render
-    sim_time : float
-        Current simulation time in seconds
-    output_dir : str
-        Output directory path for rendered frames
-    frame_index : int
-        Current frame index
-
-    Returns:
-    --------
-    None
-    """
-
     # Create output directory if it doesn't exist
     output_path = Path(output_dir)
     output_path.mkdir(parents=True, exist_ok=True)
@@ -78,12 +59,6 @@ def render_callback(scene, sim_time, output_dir, frame_index):
 
 
 def render_callback_with_multiple_cameras(scene, sim_time, output_dir, frame_index):
-    """
-    Example callback that renders from multiple camera angles.
-
-    This demonstrates how you can render multiple views in a single callback.
-    """
-
     output_path = Path(output_dir)
     output_path.mkdir(parents=True, exist_ok=True)
 

--- a/src/cavise/sionna/environment/CMakeLists.txt
+++ b/src/cavise/sionna/environment/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(sionna-phy
         config/dynamic/TraciCoordinateTransformer.cc
         config/dynamic/TraciRelaxedCoordinateTransformer.cc
         visualization/SionnaSceneVisualizer.cc
+        visualization/PythonRendererCallback.cc
     PUBLIC
         Compat.h
         Ground.h
@@ -36,6 +37,7 @@ target_sources(sionna-phy
         config/dynamic/TraciRelaxedCoordinateTransformer.h
         visualization/ISceneVisualizer.h
         visualization/SionnaSceneVisualizer.h
+        visualization/PythonRendererCallback.h
 )
 
 set_target_properties(sionna-phy

--- a/src/cavise/sionna/environment/visualization/PythonRendererCallback.cc
+++ b/src/cavise/sionna/environment/visualization/PythonRendererCallback.cc
@@ -1,0 +1,118 @@
+#include "PythonRendererCallback.h"
+
+#include <omnetpp/cexception.h>
+
+#include <nanobind/nanobind.h>
+
+#include <filesystem>
+#include <stdexcept>
+
+using namespace artery::sionna;
+
+bool PythonRendererCallback::resolve(const std::string& rendererSpec) {
+    if (rendererSpec.empty()) {
+        return false;
+    }
+
+    try {
+        nanobind::gil_scoped_acquire gil;
+
+        // Parse "module:function" or "path/to/file.py:function" format
+        auto pos = rendererSpec.find_last_of(':');
+        if (pos == std::string::npos) {
+            throw omnetpp::cRuntimeError(
+                "PythonRendererCallback: Invalid renderer format '%s'. Expected 'module:function' or 'path/to/file.py:function'",
+                rendererSpec.c_str());
+        }
+
+        std::string moduleName = rendererSpec.substr(0, pos);
+        std::string functionName = rendererSpec.substr(pos + 1);
+
+        nanobind::object module;
+
+        // Check if moduleName is a file path (contains path separators or .py extension)
+        bool isFilePath = (moduleName.find('/') != std::string::npos ||
+                           moduleName.find('\\') != std::string::npos ||
+                           moduleName.ends_with(".py"));
+
+        if (isFilePath) {
+            // Convert to absolute path to ensure we can find the file
+            std::filesystem::path modulePath(moduleName);
+            if (!modulePath.is_absolute()) {
+                // Resolve relative to the current working directory
+                modulePath = std::filesystem::absolute(modulePath);
+            }
+
+            if (!std::filesystem::exists(modulePath)) {
+                throw omnetpp::cRuntimeError(
+                    "PythonRendererCallback: Python renderer file not found: '%s' (resolved to '%s')",
+                    moduleName.c_str(), modulePath.string().c_str());
+            }
+
+            // Use importlib.util to load module from file path
+            auto importlib = nanobind::module_::import_("importlib");
+            auto util = importlib.attr("util");
+
+            // Create module spec from file location
+            auto spec_from_file = util.attr("spec_from_file_location");
+            auto spec = spec_from_file("sionna_dynamic_renderer", modulePath.string());
+
+            if (spec.is_none()) {
+                throw omnetpp::cRuntimeError(
+                    "PythonRendererCallback: Failed to create module spec for '%s'",
+                    modulePath.string().c_str());
+            }
+
+            // Create module from spec
+            auto module_from_spec = util.attr("module_from_spec");
+            module = module_from_spec(spec);
+
+            // Execute the module
+            auto loader = spec.attr("loader");
+            loader.attr("exec_module")(module);
+
+        } else {
+            // Traditional module import (e.g., "my_package:my_module")
+            module = nanobind::module_::import_(moduleName.c_str());
+        }
+
+        nanobind::object func = module.attr(functionName.c_str());
+
+        if (!nanobind::isinstance<nanobind::callable>(func)) {
+            throw omnetpp::cRuntimeError(
+                "PythonRendererCallback: '%s' is not callable in module '%s'",
+                functionName.c_str(), moduleName.c_str());
+        }
+
+        callback_ = func;
+        return true;
+
+    } catch (const nanobind::python_error& error) {
+        throw omnetpp::cRuntimeError(
+            "PythonRendererCallback: Failed to resolve renderer '%s': %s",
+            rendererSpec.c_str(), error.what());
+    }
+}
+
+void PythonRendererCallback::invoke(py::SionnaScene scene, double simTime, const std::string& outputDir, int frameIndex) {
+    if (!callback_.is_valid()) {
+        throw omnetpp::cRuntimeError("PythonRendererCallback: Cannot invoke null callback");
+    }
+
+    try {
+        nanobind::gil_scoped_acquire gil;
+        nanobind::dict kwargs;
+        kwargs["scene"] = scene.object();
+        kwargs["sim_time"] = simTime;
+        kwargs["output_dir"] = outputDir;
+        kwargs["frame_index"] = frameIndex;
+
+        callback_(**kwargs);
+    } catch (const nanobind::python_error& error) {
+        throw omnetpp::cRuntimeError("PythonRendererCallback: Callback invocation failed: %s", error.what());
+    }
+}
+
+bool PythonRendererCallback::isValid() const {
+    return callback_.is_valid();
+}

--- a/src/cavise/sionna/environment/visualization/PythonRendererCallback.h
+++ b/src/cavise/sionna/environment/visualization/PythonRendererCallback.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <cavise/sionna/bridge/bindings/Scene.h>
+
+#include <nanobind/nanobind.h>
+
+#include <string>
+
+namespace artery::sionna {
+
+    /**
+     * @brief Encapsulates a Python callback function for custom scene rendering.
+     *
+     * This class handles resolution of Python renderer specifications in the format
+     * "path/to/file.py:function" or "module:function" and provides a method
+     * to invoke the callback with the necessary parameters.
+     */
+    class PythonRendererCallback {
+    public:
+        PythonRendererCallback() = default;
+
+        /**
+         * @brief Resolve a Python renderer from a specification string.
+         *
+         * @param rendererSpec Specification in format "path/to/file.py:function"
+         *                    or "module:function"
+         * @return true if resolution was successful
+         * @return false if spec is empty or resolution failed
+         */
+        bool resolve(const std::string& rendererSpec);
+
+        /**
+         * @brief Invoke the Python callback with the given parameters.
+         *
+         * @param scene The SionnaScene object to pass to the callback
+         * @param simTime Current simulation time
+         * @param outputDir Output directory path
+         * @param frameIndex Current frame index
+         * @throws omnetpp::cRuntimeError if callback invocation fails
+         */
+        void invoke(py::SionnaScene scene, double simTime, const std::string& outputDir, int frameIndex);
+
+        /**
+         * @brief Check if a valid callback has been resolved.
+         *
+         * @return true if callback is valid and can be invoked
+         * @return false otherwise
+         */
+        bool isValid() const;
+
+    private:
+        nanobind::object callback_;
+    };
+
+} // namespace artery::sionna

--- a/src/cavise/sionna/environment/visualization/SionnaSceneVisualizer.cc
+++ b/src/cavise/sionna/environment/visualization/SionnaSceneVisualizer.cc
@@ -190,24 +190,47 @@ nanobind::object SionnaSceneVisualizer::resolvePythonRenderer(const std::string&
                            moduleName.ends_with(".py"));
 
         if (isFilePath) {
-            // Extract directory and module name from file path
+            // Convert to absolute path to ensure we can find the file
             std::filesystem::path modulePath(moduleName);
-            std::string dirPath = modulePath.parent_path().string();
-            std::string pureModuleName = modulePath.stem().string();  // removes .py extension
+            if (!modulePath.is_absolute()) {
+                // Resolve relative to the current working directory
+                modulePath = std::filesystem::absolute(modulePath);
+            }
 
-            // Add directory to sys.path so Python can find the module
-            auto sys = nanobind::module_::import_("sys");
-            auto path = nanobind::getattr(sys, "path");
-            path.attr("append")(dirPath);
+            if (!std::filesystem::exists(modulePath)) {
+                throw omnetpp::cRuntimeError(
+                    "SionnaSceneVisualizer: Python renderer file not found: '%s' (resolved to '%s')",
+                    moduleName.c_str(), modulePath.string().c_str());
+            }
 
-            // Import the module by name (without path and extension)
-            module = nanobind::module_::import_(pureModuleName.c_str());
+            // Use importlib.util to load module from file path
+            auto importlib = nanobind::module_::import_("importlib");
+            auto util = importlib.attr("util");
+
+            // Create module spec from file location
+            auto spec_from_file = util.attr("spec_from_file_location");
+            auto spec = spec_from_file("sionna_dynamic_renderer", modulePath.string());
+
+            if (spec.is_none()) {
+                throw omnetpp::cRuntimeError(
+                    "SionnaSceneVisualizer: Failed to create module spec for '%s'",
+                    modulePath.string().c_str());
+            }
+
+            // Create module from spec
+            auto module_from_spec = util.attr("module_from_spec");
+            module = module_from_spec(spec);
+
+            // Execute the module
+            auto loader = spec.attr("loader");
+            loader.attr("exec_module")(module);
+
         } else {
-            // Traditional module import (e.g., "my_package.my_module")
+            // Traditional module import (e.g., "my_package:my_module")
             module = nanobind::module_::import_(moduleName.c_str());
         }
 
-        nanobind::object func = nanobind::getattr(module, functionName.c_str());
+        nanobind::object func = module.attr(functionName.c_str());
 
         if (!nanobind::isinstance<nanobind::callable>(func)) {
             throw omnetpp::cRuntimeError(

--- a/src/cavise/sionna/environment/visualization/SionnaSceneVisualizer.cc
+++ b/src/cavise/sionna/environment/visualization/SionnaSceneVisualizer.cc
@@ -3,6 +3,8 @@
 #include <omnetpp/cexception.h>
 #include <omnetpp/cxmlelement.h>
 
+#include <nanobind/nanobind.h>
+
 #include <cstdio>
 #include <cstring>
 #include <filesystem>
@@ -20,6 +22,11 @@ void SionnaSceneVisualizer::initialize() {
     width_ = par("width").intValue();
     height_ = par("height").intValue();
     renderInterval_ = par("renderInterval");
+    pythonRendererSpec_ = par("pythonRenderer").stdstringValue();
+
+    if (!pythonRendererSpec_.empty()) {
+        pythonRenderer_ = resolvePythonRenderer(pythonRendererSpec_);
+    }
 
     renderTimer_ = new omnetpp::cMessage("sionna-render-timer");
 }
@@ -57,6 +64,26 @@ void SionnaSceneVisualizer::renderFrame() {
         return;
     }
 
+    if (pythonRenderer_) {
+        // Use custom Python renderer callback
+        try {
+            nanobind::gil_scoped_acquire gil;
+            nanobind::dict kwargs;
+            kwargs["scene"] = scene_->object();
+            kwargs["sim_time"] = omnetpp::simTime().dbl();
+            kwargs["output_dir"] = outputDir_;
+            kwargs["frame_index"] = frameIndex_;
+
+            pythonRenderer_(**kwargs);
+        } catch (const nanobind::python_error& error) {
+            throw omnetpp::cRuntimeError("SionnaSceneVisualizer: Python renderer callback failed: %s", error.what());
+        }
+
+        ++frameIndex_;
+        return;
+    }
+
+    // Default rendering logic
     const auto cameras = resolveCameras();
     for (const auto& [cameraId, camera] : cameras) {
         const auto filename = framePath(cameraId);
@@ -138,6 +165,38 @@ std::filesystem::path SionnaSceneVisualizer::framePath(const std::string& camera
     std::ostringstream name;
     name << "frame-" << std::setw(6) << std::setfill('0') << frameIndex_ << ".png";
     return std::filesystem::path(outputDir_) / cameraId / name.str();
+}
+
+nanobind::object SionnaSceneVisualizer::resolvePythonRenderer(const std::string& rendererSpec) const {
+    nanobind::gil_scoped_acquire gil;
+
+    // Parse "module.function" format
+    auto dotPos = rendererSpec.find_last_of('.');
+    if (dotPos == std::string::npos) {
+        throw omnetpp::cRuntimeError(
+            "SionnaSceneVisualizer: Invalid pythonRenderer format '%s'. Expected 'module.function'",
+            rendererSpec.c_str());
+    }
+
+    std::string moduleName = rendererSpec.substr(0, dotPos);
+    std::string functionName = rendererSpec.substr(dotPos + 1);
+
+    try {
+        nanobind::module_ module = nanobind::module_::import_(moduleName.c_str());
+        nanobind::object func = nanobind::getattr(module, functionName.c_str());
+
+        if (!nanobind::isinstance<nanobind::callable>(func)) {
+            throw omnetpp::cRuntimeError(
+                "SionnaSceneVisualizer: '%s' is not callable in module '%s'",
+                functionName.c_str(), moduleName.c_str());
+        }
+
+        return func;
+    } catch (const nanobind::python_error& error) {
+        throw omnetpp::cRuntimeError(
+            "SionnaSceneVisualizer: Failed to resolve pythonRenderer '%s': %s",
+            rendererSpec.c_str(), error.what());
+    }
 }
 
 void SionnaSceneVisualizer::scheduleNextRender() {

--- a/src/cavise/sionna/environment/visualization/SionnaSceneVisualizer.cc
+++ b/src/cavise/sionna/environment/visualization/SionnaSceneVisualizer.cc
@@ -25,7 +25,7 @@ void SionnaSceneVisualizer::initialize() {
     pythonRendererSpec_ = par("pythonRenderer").stdstringValue();
 
     if (!pythonRendererSpec_.empty()) {
-        pythonRenderer_ = resolvePythonRenderer(pythonRendererSpec_);
+        pythonRenderer_.resolve(pythonRendererSpec_);
     }
 
     renderTimer_ = new omnetpp::cMessage("sionna-render-timer");
@@ -64,40 +64,14 @@ void SionnaSceneVisualizer::renderFrame() {
         return;
     }
 
-    if (pythonRenderer_) {
+    if (pythonRenderer_.isValid()) {
         // Use custom Python renderer callback
-        try {
-            nanobind::gil_scoped_acquire gil;
-            nanobind::dict kwargs;
-            kwargs["scene"] = scene_->object();
-            kwargs["sim_time"] = omnetpp::simTime().dbl();
-            kwargs["output_dir"] = outputDir_;
-            kwargs["frame_index"] = frameIndex_;
-
-            pythonRenderer_(**kwargs);
-        } catch (const nanobind::python_error& error) {
-            throw omnetpp::cRuntimeError("SionnaSceneVisualizer: Python renderer callback failed: %s", error.what());
-        }
-
+        pythonRenderer_.invoke(*scene_, omnetpp::simTime().dbl(), outputDir_, frameIndex_);
         ++frameIndex_;
         return;
+    } else {
+        throw omnetpp::cRuntimeError("PythonRendererCallback: Invalid renderer");
     }
-
-    // Default rendering logic
-    const auto cameras = resolveCameras();
-    for (const auto& [cameraId, camera] : cameras) {
-        const auto filename = framePath(cameraId);
-        std::filesystem::create_directories(filename.parent_path());
-
-        scene_->renderToFile(
-            camera,
-            filename.string(),
-            spp_,
-            width_,
-            height_);
-    }
-
-    ++frameIndex_;
 }
 
 std::vector<std::pair<std::string, py::Camera>> SionnaSceneVisualizer::resolveCameras() const {
@@ -165,85 +139,6 @@ std::filesystem::path SionnaSceneVisualizer::framePath(const std::string& camera
     std::ostringstream name;
     name << "frame-" << std::setw(6) << std::setfill('0') << frameIndex_ << ".png";
     return std::filesystem::path(outputDir_) / cameraId / name.str();
-}
-
-nanobind::object SionnaSceneVisualizer::resolvePythonRenderer(const std::string& rendererSpec) const {
-    nanobind::gil_scoped_acquire gil;
-
-    // Parse "module:function" or "path/to/file.py:function" format
-    auto pos = rendererSpec.find_last_of(':');
-    if (pos == std::string::npos) {
-        throw omnetpp::cRuntimeError(
-            "SionnaSceneVisualizer: Invalid pythonRenderer format '%s'. Expected 'module:function' or 'path/to/file.py:function'",
-            rendererSpec.c_str());
-    }
-
-    std::string moduleName = rendererSpec.substr(0, pos);
-    std::string functionName = rendererSpec.substr(pos + 1);
-
-    try {
-        nanobind::object module;
-
-        // Check if moduleName is a file path (contains path separators or .py extension)
-        bool isFilePath = (moduleName.find('/') != std::string::npos ||
-                           moduleName.find('\\') != std::string::npos ||
-                           moduleName.ends_with(".py"));
-
-        if (isFilePath) {
-            // Convert to absolute path to ensure we can find the file
-            std::filesystem::path modulePath(moduleName);
-            if (!modulePath.is_absolute()) {
-                // Resolve relative to the current working directory
-                modulePath = std::filesystem::absolute(modulePath);
-            }
-
-            if (!std::filesystem::exists(modulePath)) {
-                throw omnetpp::cRuntimeError(
-                    "SionnaSceneVisualizer: Python renderer file not found: '%s' (resolved to '%s')",
-                    moduleName.c_str(), modulePath.string().c_str());
-            }
-
-            // Use importlib.util to load module from file path
-            auto importlib = nanobind::module_::import_("importlib");
-            auto util = importlib.attr("util");
-
-            // Create module spec from file location
-            auto spec_from_file = util.attr("spec_from_file_location");
-            auto spec = spec_from_file("sionna_dynamic_renderer", modulePath.string());
-
-            if (spec.is_none()) {
-                throw omnetpp::cRuntimeError(
-                    "SionnaSceneVisualizer: Failed to create module spec for '%s'",
-                    modulePath.string().c_str());
-            }
-
-            // Create module from spec
-            auto module_from_spec = util.attr("module_from_spec");
-            module = module_from_spec(spec);
-
-            // Execute the module
-            auto loader = spec.attr("loader");
-            loader.attr("exec_module")(module);
-
-        } else {
-            // Traditional module import (e.g., "my_package:my_module")
-            module = nanobind::module_::import_(moduleName.c_str());
-        }
-
-        nanobind::object func = module.attr(functionName.c_str());
-
-        if (!nanobind::isinstance<nanobind::callable>(func)) {
-            throw omnetpp::cRuntimeError(
-                "SionnaSceneVisualizer: '%s' is not callable in module '%s'",
-                functionName.c_str(), moduleName.c_str());
-        }
-
-        return func;
-    } catch (const nanobind::python_error& error) {
-        throw omnetpp::cRuntimeError(
-            "SionnaSceneVisualizer: Failed to resolve pythonRenderer '%s': %s",
-            rendererSpec.c_str(), error.what());
-    }
 }
 
 void SionnaSceneVisualizer::scheduleNextRender() {

--- a/src/cavise/sionna/environment/visualization/SionnaSceneVisualizer.cc
+++ b/src/cavise/sionna/environment/visualization/SionnaSceneVisualizer.cc
@@ -170,19 +170,43 @@ std::filesystem::path SionnaSceneVisualizer::framePath(const std::string& camera
 nanobind::object SionnaSceneVisualizer::resolvePythonRenderer(const std::string& rendererSpec) const {
     nanobind::gil_scoped_acquire gil;
 
-    // Parse "module.function" format
-    auto dotPos = rendererSpec.find_last_of('.');
-    if (dotPos == std::string::npos) {
+    // Parse "module:function" or "path/to/file.py:function" format
+    auto pos = rendererSpec.find_last_of(':');
+    if (pos == std::string::npos) {
         throw omnetpp::cRuntimeError(
-            "SionnaSceneVisualizer: Invalid pythonRenderer format '%s'. Expected 'module.function'",
+            "SionnaSceneVisualizer: Invalid pythonRenderer format '%s'. Expected 'module:function' or 'path/to/file.py:function'",
             rendererSpec.c_str());
     }
 
-    std::string moduleName = rendererSpec.substr(0, dotPos);
-    std::string functionName = rendererSpec.substr(dotPos + 1);
+    std::string moduleName = rendererSpec.substr(0, pos);
+    std::string functionName = rendererSpec.substr(pos + 1);
 
     try {
-        nanobind::module_ module = nanobind::module_::import_(moduleName.c_str());
+        nanobind::object module;
+
+        // Check if moduleName is a file path (contains path separators or .py extension)
+        bool isFilePath = (moduleName.find('/') != std::string::npos ||
+                           moduleName.find('\\') != std::string::npos ||
+                           moduleName.ends_with(".py"));
+
+        if (isFilePath) {
+            // Extract directory and module name from file path
+            std::filesystem::path modulePath(moduleName);
+            std::string dirPath = modulePath.parent_path().string();
+            std::string pureModuleName = modulePath.stem().string();  // removes .py extension
+
+            // Add directory to sys.path so Python can find the module
+            auto sys = nanobind::module_::import_("sys");
+            auto path = nanobind::getattr(sys, "path");
+            path.attr("append")(dirPath);
+
+            // Import the module by name (without path and extension)
+            module = nanobind::module_::import_(pureModuleName.c_str());
+        } else {
+            // Traditional module import (e.g., "my_package.my_module")
+            module = nanobind::module_::import_(moduleName.c_str());
+        }
+
         nanobind::object func = nanobind::getattr(module, functionName.c_str());
 
         if (!nanobind::isinstance<nanobind::callable>(func)) {

--- a/src/cavise/sionna/environment/visualization/SionnaSceneVisualizer.h
+++ b/src/cavise/sionna/environment/visualization/SionnaSceneVisualizer.h
@@ -2,6 +2,9 @@
 
 #include <cavise/sionna/environment/visualization/ISceneVisualizer.h>
 #include <cavise/sionna/bridge/bindings/Camera.h>
+#include <cavise/sionna/bridge/bindings/Scene.h>
+
+#include <nanobind/nanobind.h>
 
 #include <omnetpp/cmessage.h>
 #include <omnetpp/csimplemodule.h>
@@ -33,13 +36,16 @@ namespace artery::sionna {
         std::vector<std::pair<std::string, py::Camera>> resolveCameras() const;
         std::filesystem::path framePath(const std::string& cameraId) const;
         void scheduleNextRender();
+        nanobind::object resolvePythonRenderer(const std::string& rendererSpec) const;
 
     private:
         std::optional<py::SionnaScene> scene_;
         omnetpp::cMessage* renderTimer_ = nullptr;
+        nanobind::object pythonRenderer_;
 
         std::string outputDir_;
         std::string camera_;
+        std::string pythonRendererSpec_;
         int frameIndex_ = 0;
         int spp_ = 16;
         int width_ = 1280;

--- a/src/cavise/sionna/environment/visualization/SionnaSceneVisualizer.h
+++ b/src/cavise/sionna/environment/visualization/SionnaSceneVisualizer.h
@@ -1,10 +1,9 @@
 #pragma once
 
 #include <cavise/sionna/environment/visualization/ISceneVisualizer.h>
+#include <cavise/sionna/environment/visualization/PythonRendererCallback.h>
 #include <cavise/sionna/bridge/bindings/Camera.h>
 #include <cavise/sionna/bridge/bindings/Scene.h>
-
-#include <nanobind/nanobind.h>
 
 #include <omnetpp/cmessage.h>
 #include <omnetpp/csimplemodule.h>
@@ -36,12 +35,11 @@ namespace artery::sionna {
         std::vector<std::pair<std::string, py::Camera>> resolveCameras() const;
         std::filesystem::path framePath(const std::string& cameraId) const;
         void scheduleNextRender();
-        nanobind::object resolvePythonRenderer(const std::string& rendererSpec) const;
 
     private:
         std::optional<py::SionnaScene> scene_;
         omnetpp::cMessage* renderTimer_ = nullptr;
-        nanobind::object pythonRenderer_;
+        PythonRendererCallback pythonRenderer_;
 
         std::string outputDir_;
         std::string camera_;

--- a/src/cavise/sionna/environment/visualization/SionnaSceneVisualizer.ned
+++ b/src/cavise/sionna/environment/visualization/SionnaSceneVisualizer.ned
@@ -13,4 +13,5 @@ simple SionnaSceneVisualizer like ISceneVisualizer
         int width = default(1280);
         int height = default(720);
         double renderInterval @unit(s) = default(0s);
+        string pythonRenderer = default("");
 }


### PR DESCRIPTION
Added the option for custom callbacks for SionnaSceneVisualizer.
The parameter for specifying the callback is defined in omnetpp.ini:
```
*.physicalEnvironment.sceneVisualizer.pythonRenderer = “path/to/file.py:function”
```

closes #60 