### PR TITLE
[Sionna] Module hooks to run python code for sionna physical scene

### DIFF
--- a/src/cavise/sionna/environment/CMakeLists.txt
+++ b/src/cavise/sionna/environment/CMakeLists.txt
@@ -23,6 +23,7 @@ target_sources(sionna-phy
         config/dynamic/SionnaVehicleActor.cc
         config/dynamic/TraciDynamicSceneConfigProvider.cc
         visualization/SionnaSceneVisualizer.cc
+        hook/SionnaPythonHook.cc
     PUBLIC
         Compat.h
         PathLoss.h
@@ -50,6 +51,8 @@ target_sources(sionna-phy
         config/dynamic/TraciDynamicSceneConfigProvider.h
         visualization/ISceneVisualizer.h
         visualization/SionnaSceneVisualizer.h
+        hook/ISionnaPythonHook.h
+        hook/SionnaPythonHook.h
 )
 
 set_target_properties(sionna-phy

--- a/src/cavise/sionna/environment/PhysicalEnvironment.ned
+++ b/src/cavise/sionna/environment/PhysicalEnvironment.ned
@@ -5,6 +5,7 @@ import cavise.sionna.environment.config.dynamic.TraciDynamicSceneConfigProvider;
 import cavise.sionna.environment.config.meshes.IMeshRegistry;
 import cavise.sionna.environment.config.scenes.IStaticSceneProvider;
 import cavise.sionna.environment.visualization.ISceneVisualizer;
+import cavise.sionna.environment.hook.ISionnaPythonHook;
 
 //
 // Extension of INET PhysicalEnvironment that mirrors the configured physical
@@ -26,6 +27,7 @@ module SionnaPhysicalEnvironment extends PhysicalEnvironment
         string meshRegistryType = default("cavise.sionna.environment.config.meshes.SionnaDirectAssetMeshRegistry");
         string sceneVisualizerType = default("cavise.sionna.environment.visualization.SionnaSceneVisualizer");
         string traciNodeManagerModule = default("^.traci.nodes");
+        string pythonHookType = default("");  // Set to "cavise.sionna.environment.hook.SionnaPythonHook" to enable Python hook
         xml remapMatrix = default(xmldoc("transforms.xml", "/transforms/identity"));
         xml rotationMatrix = default(xmldoc("transforms.xml", "/transforms/identity"));
         xml translationVector = default(xmldoc("transforms.xml", "/transforms/zero"));
@@ -45,5 +47,9 @@ module SionnaPhysicalEnvironment extends PhysicalEnvironment
 
         sceneVisualizer: <sceneVisualizerType> like ISceneVisualizer if sceneVisualizerType != "" {
             @display("p=140,220");
+        }
+
+        pythonHook: <pythonHookType> like ISionnaPythonHook if pythonHookType != "" {
+            @display("p=140,250");
         }
 }

--- a/src/cavise/sionna/environment/config/dynamic/DynamicSceneConfigListener.cc
+++ b/src/cavise/sionna/environment/config/dynamic/DynamicSceneConfigListener.cc
@@ -26,7 +26,7 @@ void DynamicSceneConfigListener::unsubscribeFromDynamicSceneUpdates() {
     }
 }
 
-void DynamicSceneConfigListener::receiveSignal(omnetpp::cComponent* /* source */, omnetpp::simsignal_t signal, unsigned long /* value */, omnetpp::cObject* /* details */) {
+void DynamicSceneConfigListener::receiveSignal(omnetpp::cComponent* /* source */, omnetpp::simsignal_t signal, const omnetpp::SimTime& /* value */, omnetpp::cObject* /* details */) {
     if (signal == TraciDynamicSceneConfigProvider::sceneEditEndSignal) {
         onDynamicSceneEdited();
     }

--- a/src/cavise/sionna/environment/config/dynamic/DynamicSceneConfigListener.cc
+++ b/src/cavise/sionna/environment/config/dynamic/DynamicSceneConfigListener.cc
@@ -16,18 +16,18 @@ void DynamicSceneConfigListener::subscribeToDynamicSceneUpdates(omnetpp::cModule
         throw omnetpp::cRuntimeError("could not resolve Sionna dynamic scene config provider from module %s", context->getFullPath().c_str());
     }
 
-    dynamicSceneConfigProvider_->subscribe(TraciDynamicSceneConfigProvider::sceneEdited, this);
+    dynamicSceneConfigProvider_->subscribe(TraciDynamicSceneConfigProvider::sceneEditEndSignal, this);
 }
 
 void DynamicSceneConfigListener::unsubscribeFromDynamicSceneUpdates() {
     if (dynamicSceneConfigProvider_ != nullptr) {
-        dynamicSceneConfigProvider_->unsubscribe(TraciDynamicSceneConfigProvider::sceneEdited, this);
+        dynamicSceneConfigProvider_->unsubscribe(TraciDynamicSceneConfigProvider::sceneEditEndSignal, this);
         dynamicSceneConfigProvider_ = nullptr;
     }
 }
 
 void DynamicSceneConfigListener::receiveSignal(omnetpp::cComponent* /* source */, omnetpp::simsignal_t signal, unsigned long /* value */, omnetpp::cObject* /* details */) {
-    if (signal == TraciDynamicSceneConfigProvider::sceneEdited) {
+    if (signal == TraciDynamicSceneConfigProvider::sceneEditEndSignal) {
         onDynamicSceneEdited();
     }
 }

--- a/src/cavise/sionna/environment/config/dynamic/DynamicSceneConfigListener.h
+++ b/src/cavise/sionna/environment/config/dynamic/DynamicSceneConfigListener.h
@@ -18,7 +18,7 @@ namespace artery::sionna {
         void unsubscribeFromDynamicSceneUpdates();
 
         // omnetpp::cListener implementation.
-        void receiveSignal(omnetpp::cComponent* source, omnetpp::simsignal_t signal, unsigned long value, omnetpp::cObject* details) override;
+        void receiveSignal(omnetpp::cComponent* source, omnetpp::simsignal_t signal, const omnetpp::SimTime& value, omnetpp::cObject* details) override;
 
     protected:
 

--- a/src/cavise/sionna/environment/config/dynamic/TraciDynamicSceneConfigProvider.cc
+++ b/src/cavise/sionna/environment/config/dynamic/TraciDynamicSceneConfigProvider.cc
@@ -14,7 +14,6 @@ Define_Module(TraciDynamicSceneConfigProvider);
 // Define static signal members
 omnetpp::simsignal_t TraciDynamicSceneConfigProvider::sceneEditBeginSignal = omnetpp::cComponent::registerSignal("sceneEditBegin");
 omnetpp::simsignal_t TraciDynamicSceneConfigProvider::sceneEditEndSignal = omnetpp::cComponent::registerSignal("sceneEditEnd");
-omnetpp::simsignal_t TraciDynamicSceneConfigProvider::sceneEdited = omnetpp::cComponent::registerSignal("sceneEdited");
 
 void TraciDynamicSceneConfigProvider::initialize() {
     api_ = ISionnaAPI::get(this);
@@ -41,5 +40,4 @@ void TraciDynamicSceneConfigProvider::edit() {
     api_->dynamicConfiguration()->edit();
     // Emit signal after scene edit
     emit(sceneEditEndSignal, simTime());
-    emit(sceneEdited, 1UL);
 }

--- a/src/cavise/sionna/environment/config/dynamic/TraciDynamicSceneConfigProvider.cc
+++ b/src/cavise/sionna/environment/config/dynamic/TraciDynamicSceneConfigProvider.cc
@@ -11,6 +11,9 @@ using namespace artery::sionna;
 
 Define_Module(TraciDynamicSceneConfigProvider);
 
+// Define static signal members
+omnetpp::simsignal_t TraciDynamicSceneConfigProvider::sceneEditBeginSignal = omnetpp::cComponent::registerSignal("sceneEditBegin");
+omnetpp::simsignal_t TraciDynamicSceneConfigProvider::sceneEditEndSignal = omnetpp::cComponent::registerSignal("sceneEditEnd");
 omnetpp::simsignal_t TraciDynamicSceneConfigProvider::sceneEdited = omnetpp::cComponent::registerSignal("sceneEdited");
 
 void TraciDynamicSceneConfigProvider::initialize() {
@@ -33,6 +36,10 @@ void TraciDynamicSceneConfigProvider::receiveSignal(omnetpp::cComponent* /* sour
 }
 
 void TraciDynamicSceneConfigProvider::edit() {
+    // Emit signal before scene edit
+    emit(sceneEditBeginSignal, simTime());
     api_->dynamicConfiguration()->edit();
+    // Emit signal after scene edit
+    emit(sceneEditEndSignal, simTime());
     emit(sceneEdited, 1UL);
 }

--- a/src/cavise/sionna/environment/config/dynamic/TraciDynamicSceneConfigProvider.h
+++ b/src/cavise/sionna/environment/config/dynamic/TraciDynamicSceneConfigProvider.h
@@ -15,6 +15,8 @@ namespace artery::sionna {
         , public omnetpp::cListener {
     public:
         static omnetpp::simsignal_t sceneEdited;
+        static omnetpp::simsignal_t sceneEditBeginSignal;
+        static omnetpp::simsignal_t sceneEditEndSignal;
 
         TraciDynamicSceneConfigProvider() = default;
 
@@ -32,8 +34,6 @@ namespace artery::sionna {
         ISionnaAPI* api_ = nullptr;
         traci::BasicNodeManager* traciNodeManager_ = nullptr;
         // Signals for notifying scene edit operations.
-        static omnetpp::simsignal_t sceneEditBeginSignal;
-        static omnetpp::simsignal_t sceneEditEndSignal;
     };
 
 } // namespace artery::sionna

--- a/src/cavise/sionna/environment/config/dynamic/TraciDynamicSceneConfigProvider.h
+++ b/src/cavise/sionna/environment/config/dynamic/TraciDynamicSceneConfigProvider.h
@@ -14,7 +14,6 @@ namespace artery::sionna {
         : public omnetpp::cSimpleModule
         , public omnetpp::cListener {
     public:
-        static omnetpp::simsignal_t sceneEdited;
         static omnetpp::simsignal_t sceneEditBeginSignal;
         static omnetpp::simsignal_t sceneEditEndSignal;
 

--- a/src/cavise/sionna/environment/config/dynamic/TraciDynamicSceneConfigProvider.h
+++ b/src/cavise/sionna/environment/config/dynamic/TraciDynamicSceneConfigProvider.h
@@ -31,6 +31,9 @@ namespace artery::sionna {
     private:
         ISionnaAPI* api_ = nullptr;
         traci::BasicNodeManager* traciNodeManager_ = nullptr;
+        // Signals for notifying scene edit operations.
+        static omnetpp::simsignal_t sceneEditBeginSignal;
+        static omnetpp::simsignal_t sceneEditEndSignal;
     };
 
 } // namespace artery::sionna

--- a/src/cavise/sionna/environment/hook/ISionnaPythonHook.h
+++ b/src/cavise/sionna/environment/hook/ISionnaPythonHook.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <omnetpp/csimplemodule.h>
+
+namespace artery::sionna {
+
+    // Interface for Sionna Python Hook modules.
+    // This interface allows the PhysicalEnvironment to discover and manage
+    // Python hook modules without knowing the concrete implementation.
+    class ISionnaPythonHook : public omnetpp::cSimpleModule {
+    public:
+        virtual ~ISionnaPythonHook() = default;
+
+        // Called when the Python module has been loaded successfully.
+        virtual void onPythonModuleLoaded() = 0;
+
+        // Called when the scene is about to be edited (before edit).
+        virtual void onSceneEditBegin() = 0;
+
+        // Called after the scene has been edited (after edit).
+        virtual void onSceneEditEnd() = 0;
+    };
+
+} // namespace artery::sionna

--- a/src/cavise/sionna/environment/hook/ISionnaPythonHook.ned
+++ b/src/cavise/sionna/environment/hook/ISionnaPythonHook.ned
@@ -7,6 +7,13 @@ package cavise.sionna.environment.hook;
 // Modules implementing this interface can hook into the Sionna scene
 // lifecycle and execute custom Python code at various points.
 //
+// The SionnaPythonHook implementation supports:
+// - Loading single Python files or entire packages (directories)
+// - Auto-discovery of classes decorated with @sionna_hook
+// - Backward compatibility with 'Hook' class or 'hook' attribute
+//
+// See SionnaPythonHook.ned for detailed usage documentation.
+//
 moduleinterface ISionnaPythonHook
 {
 }

--- a/src/cavise/sionna/environment/hook/ISionnaPythonHook.ned
+++ b/src/cavise/sionna/environment/hook/ISionnaPythonHook.ned
@@ -1,0 +1,12 @@
+package cavise.sionna.environment.hook;
+
+@namespace(artery::sionna);
+
+//
+// Interface for Sionna Python Hook modules.
+// Modules implementing this interface can hook into the Sionna scene
+// lifecycle and execute custom Python code at various points.
+//
+moduleinterface ISionnaPythonHook
+{
+}

--- a/src/cavise/sionna/environment/hook/SionnaPythonHook.cc
+++ b/src/cavise/sionna/environment/hook/SionnaPythonHook.cc
@@ -1,0 +1,215 @@
+#include "SionnaPythonHook.h"
+
+#include <cavise/sionna/environment/config/dynamic/TraciDynamicSceneConfigProvider.h>
+
+#include <traci/Core.h>
+
+#include <nanobind/nanobind.h>
+
+#include <omnetpp/ccomponent.h>
+#include <omnetpp/cexception.h>
+#include <omnetpp/cmodule.h>
+#include <omnetpp/cregistrationlist.h>
+#include <omnetpp/csimulation.h>
+#include <omnetpp/simtime.h>
+
+#include <filesystem>
+#include <inet/common/InitStages.h>
+
+using namespace artery::sionna;
+using namespace nanobind;
+
+Define_Module(SionnaPythonHook);
+
+// Define static signal members for TraCI
+omnetpp::simsignal_t SionnaPythonHook::traciInitSignal_ = omnetpp::cComponent::registerSignal("traci.init");
+omnetpp::simsignal_t SionnaPythonHook::traciStepSignal_ = omnetpp::cComponent::registerSignal("traci.step");
+omnetpp::simsignal_t SionnaPythonHook::traciCloseSignal_ = omnetpp::cComponent::registerSignal("traci.close");
+
+// Define static signal members for scene edit
+omnetpp::simsignal_t SionnaPythonHook::sceneEditBeginSignal_ = omnetpp::cComponent::registerSignal("sceneEditBegin");
+omnetpp::simsignal_t SionnaPythonHook::sceneEditEndSignal_ = omnetpp::cComponent::registerSignal("sceneEditEnd");
+
+int SionnaPythonHook::numInitStages() const {
+    return inet::NUM_INIT_STAGES;
+}
+
+void SionnaPythonHook::initialize(int stage) {
+    if (stage == inet::InitStages::INITSTAGE_LOCAL) {
+        // Get parameters.
+        pythonModulePath_ = par("pythonModulePath").stdstringValue();
+
+        // Get references to modules for signal subscription.
+        traciCoreModule_ = getModuleByPath(par("traciCoreModule").stringValue());
+        if (!traciCoreModule_) {
+            throw omnetpp::cRuntimeError("SionnaPythonHook: traciCoreModule not found at path '%s'",
+                                         par("traciCoreModule").stringValue());
+        }
+
+        sceneConfigProviderModule_ = getModuleByPath(par("sceneConfigProviderModule").stringValue());
+        if (!sceneConfigProviderModule_) {
+            throw omnetpp::cRuntimeError("SionnaPythonHook: sceneConfigProviderModule not found at path '%s'",
+                                         par("sceneConfigProviderModule").stringValue());
+        }
+    } else if (stage == inet::InitStages::INITSTAGE_PHYSICAL_ENVIRONMENT) {
+        // Python runtime should be initialized by now (done at INITSTAGE_LOCAL by PhysicalEnvironment).
+        // Load the Python module.
+        loadPythonModule();
+
+        // Subscribe to TraCI signals.
+        traciCoreModule_->subscribe(traciInitSignal_, this);
+        traciCoreModule_->subscribe(traciStepSignal_, this);
+        traciCoreModule_->subscribe(traciCloseSignal_, this);
+
+        // Subscribe to scene edit signals.
+        sceneConfigProviderModule_->subscribe(sceneEditBeginSignal_, this);
+        sceneConfigProviderModule_->subscribe(sceneEditEndSignal_, this);
+    }
+}
+
+void SionnaPythonHook::finish() {
+    // Unsubscribe from signals.
+    if (traciCoreModule_) {
+        traciCoreModule_->unsubscribe(traciInitSignal_, this);
+        traciCoreModule_->unsubscribe(traciStepSignal_, this);
+        traciCoreModule_->unsubscribe(traciCloseSignal_, this);
+    }
+
+    if (sceneConfigProviderModule_) {
+        sceneConfigProviderModule_->unsubscribe(sceneEditBeginSignal_, this);
+        sceneConfigProviderModule_->unsubscribe(sceneEditEndSignal_, this);
+    }
+
+    // Clear Python objects (they will be destroyed when the interpreter shuts down).
+    pythonHookInstance_.reset();
+    pythonModule_.reset();
+}
+
+void SionnaPythonHook::loadPythonModule() {
+    if (pythonModulePath_.empty()) {
+        throw omnetpp::cRuntimeError("SionnaPythonHook: pythonModulePath parameter is empty");
+    }
+
+    try {
+        gil_scoped_acquire gil;
+
+        // The pythonModulePath_ can be:
+        // 1. A module path like "myapp.hooks.my_hook" (Python import path)
+        // 2. A file path like "/path/to/my_hook.py"
+        // For file paths, we need to add the parent directory to sys.path.
+
+        std::string moduleName = pythonModulePath_;
+        std::filesystem::path path(pythonModulePath_);
+
+        if (path.extension() == ".py" || std::filesystem::exists(path)) {
+            // It's a file path - need to add parent to sys.path and import by stem name.
+            auto parentPath = path.parent_path();
+            auto stem = path.stem().string();
+
+            // Add parent path to sys.path if not already there.
+            nanobind::module_ sys = nanobind::module_::import_("sys");
+            nanobind::object pathList = sys.attr("path");
+
+            // Check if parent path is already in sys.path.
+            bool found = false;
+            for (auto item : pathList) {
+                if (nanobind::cast<std::string>(item) == parentPath.string()) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                pathList.attr("append")(parentPath.string());
+            }
+
+            moduleName = stem;
+        }
+
+        EV_INFO << "SionnaPythonHook: Loading Python module '" << moduleName << "'" << std::endl;
+
+        // Import the module.
+        pythonModule_ = std::make_unique<object>(nanobind::module_::import_(moduleName.c_str()));
+
+        object module = *pythonModule_;
+
+        // Try to find a hook instance.
+        // First, check if the module has a 'hook' attribute (an instance).
+        try {
+            object hookAttr = module.attr("hook");
+            pythonHookInstance_ = std::make_unique<object>(hookAttr);
+            EV_INFO << "SionnaPythonHook: Using 'hook' attribute from module" << std::endl;
+        } catch (const nanobind::python_error&) {
+            // No 'hook' attribute, try to find a Hook class.
+            try {
+                object hookClass = module.attr("Hook");
+                // Instantiate the class.
+                pythonHookInstance_ = std::make_unique<object>(hookClass());
+                EV_INFO << "SionnaPythonHook: Instantiated 'Hook' class from module" << std::endl;
+            } catch (const nanobind::python_error&) {
+                // No Hook class either - use the module itself as the hook object.
+                pythonHookInstance_ = std::make_unique<object>(module);
+                EV_INFO << "SionnaPythonHook: Using module itself as hook object" << std::endl;
+            }
+        }
+
+        // Notify that Python module is loaded.
+        onPythonModuleLoaded();
+
+        EV_INFO << "SionnaPythonHook: Python module loaded successfully" << std::endl;
+
+    } catch (const nanobind::python_error& e) {
+        throw omnetpp::cRuntimeError("SionnaPythonHook: Failed to load Python module '%s': %s",
+                                     pythonModulePath_.c_str(), e.what());
+    } catch (const std::exception& e) {
+        throw omnetpp::cRuntimeError("SionnaPythonHook: Failed to load Python module '%s': %s",
+                                     pythonModulePath_.c_str(), e.what());
+    }
+}
+
+void SionnaPythonHook::callPythonMethod(const std::string& methodName) {
+    if (!pythonHookInstance_) {
+        EV_WARN << "SionnaPythonHook: Python hook instance not loaded, skipping " << methodName << std::endl;
+        return;
+    }
+
+    try {
+        gil_scoped_acquire gil;
+        object hook = *pythonHookInstance_;
+
+        // Check if the method exists.
+        if (!nanobind::hasattr(hook, methodName.c_str())) {
+            EV_DEBUG << "SionnaPythonHook: Method '" << methodName << "' not found in Python hook, skipping" << std::endl;
+            return;
+        }
+
+        // Call the method.
+        hook.attr(methodName.c_str())();
+        EV_DEBUG << "SionnaPythonHook: Called Python method '" << methodName << "'" << std::endl;
+
+    } catch (const nanobind::python_error& e) {
+        EV_ERROR << "SionnaPythonHook: Error calling Python method '" << methodName << "': " << e.what() << std::endl;
+    }
+}
+
+void SionnaPythonHook::receiveSignal(omnetpp::cComponent* /*source*/, omnetpp::simsignal_t signal,
+                                    const omnetpp::SimTime& /*value*/, omnetpp::cObject* /*details*/) {
+    if (signal == traciInitSignal_) {
+        callPythonMethod("on_traci_init");
+    } else if (signal == traciStepSignal_) {
+        callPythonMethod("on_traci_step");
+    } else if (signal == traciCloseSignal_) {
+        callPythonMethod("on_traci_close");
+    } else if (signal == sceneEditBeginSignal_) {
+        onSceneEditBegin();
+    } else if (signal == sceneEditEndSignal_) {
+        onSceneEditEnd();
+    }
+}
+
+void SionnaPythonHook::onSceneEditBegin() {
+    callPythonMethod("on_scene_edit_begin");
+}
+
+void SionnaPythonHook::onSceneEditEnd() {
+    callPythonMethod("on_scene_edit_end");
+}

--- a/src/cavise/sionna/environment/hook/SionnaPythonHook.cc
+++ b/src/cavise/sionna/environment/hook/SionnaPythonHook.cc
@@ -1,7 +1,5 @@
 #include "SionnaPythonHook.h"
 
-#include <cavise/sionna/environment/config/dynamic/TraciDynamicSceneConfigProvider.h>
-
 #include <traci/Core.h>
 
 #include <nanobind/nanobind.h>
@@ -33,13 +31,6 @@ void SionnaPythonHook::initialize(int stage) {
     if (stage == inet::InitStages::INITSTAGE_LOCAL) {
         // Get parameters.
         pythonModulePath_ = par("pythonModulePath").stdstringValue();
-
-        // Get reference to scene config provider module for signal subscription.
-        sceneConfigProviderModule_ = getModuleByPath(par("sceneConfigProviderModule").stringValue());
-        if (!sceneConfigProviderModule_) {
-            throw omnetpp::cRuntimeError("SionnaPythonHook: sceneConfigProviderModule not found at path '%s'",
-                                         par("sceneConfigProviderModule").stringValue());
-        }
     } else if (stage == inet::InitStages::INITSTAGE_PHYSICAL_ENVIRONMENT) {
         // Python runtime should be initialized by now (done at INITSTAGE_LOCAL by PhysicalEnvironment).
         // Load the Python module.
@@ -53,9 +44,9 @@ void SionnaPythonHook::initialize(int stage) {
         }
         subscribeTraCI(traciCoreModule);
 
-        // Subscribe to scene edit signals.
-        sceneConfigProviderModule_->subscribe(sceneEditBeginSignal_, this);
-        sceneConfigProviderModule_->subscribe(sceneEditEndSignal_, this);
+        // Subscribe to scene edit signals via system module (signals propagate to top).
+        getSystemModule()->subscribe(sceneEditBeginSignal_, this);
+        getSystemModule()->subscribe(sceneEditEndSignal_, this);
     }
 }
 
@@ -63,11 +54,9 @@ void SionnaPythonHook::finish() {
     // Unsubscribe from TraCI signals using traci::Listener.
     unsubscribeTraCI();
 
-    // Unsubscribe from scene edit signals.
-    if (sceneConfigProviderModule_) {
-        sceneConfigProviderModule_->unsubscribe(sceneEditBeginSignal_, this);
-        sceneConfigProviderModule_->unsubscribe(sceneEditEndSignal_, this);
-    }
+    // Unsubscribe from scene edit signals via system module.
+    getSystemModule()->unsubscribe(sceneEditBeginSignal_, this);
+    getSystemModule()->unsubscribe(sceneEditEndSignal_, this);
 
     // Clear Python objects (they will be destroyed when the interpreter shuts down).
     pythonHookInstance_.reset();
@@ -173,8 +162,7 @@ void SionnaPythonHook::callPythonMethod(const std::string& methodName) {
 
         // Call the method.
         hook.attr(methodName.c_str())();
-        //EV_DEBUG << "SionnaPythonHook: Called Python method '" << methodName << "'" << std::endl;
-        EV_INFO << "SionnaPythonHook: Called Python method '" << methodName << "'" << std::endl;
+        EV_DEBUG << "SionnaPythonHook: Called Python method '" << methodName << "'" << std::endl;
 
     } catch (const nanobind::python_error& e) {
         EV_ERROR << "SionnaPythonHook: Error calling Python method '" << methodName << "': " << e.what() << std::endl;

--- a/src/cavise/sionna/environment/hook/SionnaPythonHook.cc
+++ b/src/cavise/sionna/environment/hook/SionnaPythonHook.cc
@@ -33,7 +33,7 @@ void SionnaPythonHook::initialize(int stage) {
         pythonModulePath_ = par("pythonModulePath").stdstringValue();
     } else if (stage == inet::InitStages::INITSTAGE_PHYSICAL_ENVIRONMENT) {
         // Python runtime should be initialized by now (done at INITSTAGE_LOCAL by PhysicalEnvironment).
-        // Load the Python module.
+        // Load the Python module(s).
         loadPythonModule();
 
         // Subscribe to TraCI signals using traci::Listener.
@@ -59,8 +59,8 @@ void SionnaPythonHook::finish() {
     getSystemModule()->unsubscribe(sceneEditEndSignal_, this);
 
     // Clear Python objects (they will be destroyed when the interpreter shuts down).
-    pythonHookInstance_.reset();
-    pythonModule_.reset();
+    pythonHookInstances_.clear();
+    pythonModules_.clear();
 }
 
 void SionnaPythonHook::loadPythonModule() {
@@ -68,16 +68,27 @@ void SionnaPythonHook::loadPythonModule() {
         throw omnetpp::cRuntimeError("SionnaPythonHook: pythonModulePath parameter is empty");
     }
 
+    std::filesystem::path path(pythonModulePath_);
+
+    // Check if it's a directory (package) or a file (module)
+    if (std::filesystem::is_directory(path)) {
+        loadPackage(pythonModulePath_);
+    } else {
+        loadSingleModule(pythonModulePath_);
+    }
+
+    // Notify that Python module(s) are loaded.
+    onPythonModuleLoaded();
+
+    EV_INFO << "SionnaPythonHook: Loaded " << pythonHookInstances_.size() << " hook instance(s)" << std::endl;
+}
+
+void SionnaPythonHook::loadSingleModule(const std::string& modulePath) {
     try {
         gil_scoped_acquire gil;
 
-        // The pythonModulePath_ can be:
-        // 1. A module path like "myapp.hooks.my_hook" (Python import path)
-        // 2. A file path like "/path/to/my_hook.py"
-        // For file paths, we need to add the parent directory to sys.path.
-
-        std::string moduleName = pythonModulePath_;
-        std::filesystem::path path(pythonModulePath_);
+        std::string moduleName = modulePath;
+        std::filesystem::path path(modulePath);
 
         if (path.extension() == ".py" || std::filesystem::exists(path)) {
             // It's a file path - need to add parent to sys.path and import by stem name.
@@ -106,57 +117,173 @@ void SionnaPythonHook::loadPythonModule() {
         EV_INFO << "SionnaPythonHook: Loading Python module '" << moduleName << "'" << std::endl;
 
         // Import the module.
-        pythonModule_ = std::make_unique<object>(nanobind::module_::import_(moduleName.c_str()));
+        auto module = std::make_unique<object>(nanobind::module_::import_(moduleName.c_str()));
+        pythonModules_.push_back(std::move(module));
 
-        object module = *pythonModule_;
-
-        // Try to find a hook instance.
-        // First, check if the module has a 'hook' attribute (an instance).
-        try {
-            object hookAttr = module.attr("hook");
-            pythonHookInstance_ = std::make_unique<object>(hookAttr);
-            EV_INFO << "SionnaPythonHook: Using 'hook' attribute from module" << std::endl;
-        } catch (const nanobind::python_error&) {
-            // No 'hook' attribute, try to find a Hook class.
-            try {
-                object hookClass = module.attr("Hook");
-                // Instantiate the class.
-                pythonHookInstance_ = std::make_unique<object>(hookClass());
-                EV_INFO << "SionnaPythonHook: Instantiated 'Hook' class from module" << std::endl;
-            } catch (const nanobind::python_error&) {
-                // No Hook class either - use the module itself as the hook object.
-                pythonHookInstance_ = std::make_unique<object>(module);
-                EV_INFO << "SionnaPythonHook: Using module itself as hook object" << std::endl;
-            }
-        }
-
-        // Notify that Python module is loaded.
-        onPythonModuleLoaded();
-
-        EV_INFO << "SionnaPythonHook: Python module loaded successfully" << std::endl;
+        // Discover hook classes in the module.
+        discoverHooksInModule(*pythonModules_.back());
 
     } catch (const nanobind::python_error& e) {
         throw omnetpp::cRuntimeError("SionnaPythonHook: Failed to load Python module '%s': %s",
-                                     pythonModulePath_.c_str(), e.what());
+                                     modulePath.c_str(), e.what());
     } catch (const std::exception& e) {
         throw omnetpp::cRuntimeError("SionnaPythonHook: Failed to load Python module '%s': %s",
-                                     pythonModulePath_.c_str(), e.what());
+                                     modulePath.c_str(), e.what());
+    }
+}
+
+void SionnaPythonHook::loadPackage(const std::string& packagePath) {
+    try {
+        gil_scoped_acquire gil;
+
+        std::filesystem::path path(packagePath);
+
+        // Add package directory to sys.path if not already there.
+        nanobind::module_ sys = nanobind::module_::import_("sys");
+        nanobind::object pathList = sys.attr("path");
+
+        bool found = false;
+        for (auto item : pathList) {
+            if (nanobind::cast<std::string>(item) == path.string()) {
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            pathList.attr("append")(path.string());
+        }
+
+        // Iterate through all Python files in the directory.
+        for (const auto& entry : std::filesystem::directory_iterator(path)) {
+            if (entry.path().extension() == ".py") {
+                std::string stem = entry.path().stem().string();
+
+                // Skip __init__.py
+                if (stem == "__init__") {
+                    continue;
+                }
+
+                EV_INFO << "SionnaPythonHook: Loading Python module '" << stem
+                        << "' from package" << std::endl;
+
+                try {
+                    auto module = std::make_unique<object>(nanobind::module_::import_(stem.c_str()));
+                    pythonModules_.push_back(std::move(module));
+
+                    // Discover hook classes in the module.
+                    discoverHooksInModule(*pythonModules_.back());
+                } catch (const nanobind::python_error& e) {
+                    EV_WARN << "SionnaPythonHook: Failed to load module '" << stem << "': " << e.what() << std::endl;
+                }
+            }
+        }
+
+    } catch (const nanobind::python_error& e) {
+        throw omnetpp::cRuntimeError("SionnaPythonHook: Failed to load Python package '%s': %s",
+                                     packagePath.c_str(), e.what());
+    } catch (const std::exception& e) {
+        throw omnetpp::cRuntimeError("SionnaPythonHook: Failed to load Python package '%s': %s",
+                                     packagePath.c_str(), e.what());
+    }
+}
+
+void SionnaPythonHook::discoverHooksInModule(const nanobind::object& module) {
+    try {
+        gil_scoped_acquire gil;
+
+        object mod = module;
+        bool hookFound = false;
+
+        // First, check if the module has a 'hook' attribute (an instance).
+        try {
+            object hookAttr = mod.attr("hook");
+            pythonHookInstances_.push_back(std::make_unique<object>(hookAttr));
+            EV_INFO << "SionnaPythonHook: Using 'hook' attribute from module" << std::endl;
+            hookFound = true;
+        } catch (const nanobind::python_error&) {
+            // No 'hook' attribute, try to find a Hook class.
+            try {
+                object hookClass = mod.attr("Hook");
+                // Check if it's marked with @sionna_hook decorator
+                try {
+                    bool isMarked = nanobind::cast<bool>(hookClass.attr("_sionna_hook_marked"));
+                    if (isMarked) {
+                        // Instantiate the class.
+                        pythonHookInstances_.push_back(std::make_unique<object>(hookClass()));
+                        EV_INFO << "SionnaPythonHook: Instantiated decorated 'Hook' class from module" << std::endl;
+                        hookFound = true;
+                    }
+                } catch (const nanobind::python_error&) {
+                    // Not decorated, instantiate anyway for backward compatibility
+                    pythonHookInstances_.push_back(std::make_unique<object>(hookClass()));
+                    EV_INFO << "SionnaPythonHook: Instantiated 'Hook' class from module (not decorated)" << std::endl;
+                    hookFound = true;
+                }
+            } catch (const nanobind::python_error&) {
+                // No Hook class - scan for all classes marked with @sionna_hook
+                try {
+                    // Use Python's dir() to get all attribute names in the module
+                    nanobind::module_ builtins = nanobind::module_::import_("builtins");
+                    nanobind::object dir_func = builtins.attr("dir");
+                    nanobind::object dir_list = dir_func(mod);
+                    int n = nanobind::cast<int>(dir_list.attr("__len__")());
+                    for (int i = 0; i < n; ++i) {
+                        nanobind::object name_obj = dir_list.attr("__getitem__")(i);
+                        std::string name = nanobind::cast<std::string>(name_obj);
+                        nanobind::object obj = mod.attr(name.c_str());
+                        // Check if obj is a class (type)
+                        nanobind::object type_func = builtins.attr("type");
+                        nanobind::object obj_type = type_func(obj);
+                        nanobind::object type_type = type_func(type_func);
+                        if (obj_type.equal(type_type)) {
+                            // It's a class, check if it's marked with @sionna_hook
+                            try {
+                                bool isMarked = nanobind::cast<bool>(obj.attr("_sionna_hook_marked"));
+                                if (isMarked) {
+                                    // Instantiate the class
+                                    pythonHookInstances_.push_back(std::make_unique<object>(obj()));
+                                    EV_INFO << "SionnaPythonHook: Instantiated decorated class from module" << std::endl;
+                                    hookFound = true;
+                                }
+                            } catch (const nanobind::python_error&) {
+                                // Not marked, skip
+                            }
+                        }
+                    }
+                } catch (const nanobind::python_error& e) {
+                    EV_WARN << "SionnaPythonHook: Error scanning for decorated classes: " << e.what() << std::endl;
+                }
+            }
+        }
+
+        // If no hook found, use the module itself as the hook object (backward compatibility)
+        if (!hookFound) {
+            pythonHookInstances_.push_back(std::make_unique<object>(mod));
+            EV_INFO << "SionnaPythonHook: Using module itself as hook object (no decorated classes found)" << std::endl;
+        }
+
+    } catch (const nanobind::python_error& e) {
+        EV_WARN << "SionnaPythonHook: Error discovering hooks in module: " << e.what() << std::endl;
     }
 }
 
 void SionnaPythonHook::callPythonMethod(const std::string& methodName) {
-    if (!pythonHookInstance_) {
-        EV_WARN << "SionnaPythonHook: Python hook instance not loaded, skipping " << methodName << std::endl;
+    if (pythonHookInstances_.empty()) {
+        EV_WARN << "SionnaPythonHook: No Python hook instances loaded, skipping " << methodName << std::endl;
         return;
     }
 
     try {
         gil_scoped_acquire gil;
-        object hook = *pythonHookInstance_;
-        
-        // Use call from SB helpers
-        call<object>(hook, methodName);
-        EV_DEBUG << "SionnaPythonHook: Called Python method '" << methodName << "'" << std::endl;
+
+        // Call the method on all hook instances.
+        for (auto& hookInstance : pythonHookInstances_) {
+            // Use call from SB helpers (in artery::sionna namespace)
+            call(*hookInstance, methodName);
+        }
+
+        EV_DEBUG << "SionnaPythonHook: Called Python method '" << methodName << "' on "
+                 << pythonHookInstances_.size() << " hook instance(s)" << std::endl;
 
     } catch (const nanobind::python_error& e) {
         EV_ERROR << "SionnaPythonHook: Error calling Python method '" << methodName << "': " << e.what() << std::endl;

--- a/src/cavise/sionna/environment/hook/SionnaPythonHook.cc
+++ b/src/cavise/sionna/environment/hook/SionnaPythonHook.cc
@@ -153,15 +153,9 @@ void SionnaPythonHook::callPythonMethod(const std::string& methodName) {
     try {
         gil_scoped_acquire gil;
         object hook = *pythonHookInstance_;
-
-        // Check if the method exists.
-        if (!nanobind::hasattr(hook, methodName.c_str())) {
-            EV_DEBUG << "SionnaPythonHook: Method '" << methodName << "' not found in Python hook, skipping" << std::endl;
-            return;
-        }
-
-        // Call the method.
-        hook.attr(methodName.c_str())();
+        
+        // Use call from SB helpers
+        call<object>(hook, methodName);
         EV_DEBUG << "SionnaPythonHook: Called Python method '" << methodName << "'" << std::endl;
 
     } catch (const nanobind::python_error& e) {

--- a/src/cavise/sionna/environment/hook/SionnaPythonHook.cc
+++ b/src/cavise/sionna/environment/hook/SionnaPythonHook.cc
@@ -21,11 +21,6 @@ using namespace nanobind;
 
 Define_Module(SionnaPythonHook);
 
-// Define static signal members for TraCI
-omnetpp::simsignal_t SionnaPythonHook::traciInitSignal_ = omnetpp::cComponent::registerSignal("traci.init");
-omnetpp::simsignal_t SionnaPythonHook::traciStepSignal_ = omnetpp::cComponent::registerSignal("traci.step");
-omnetpp::simsignal_t SionnaPythonHook::traciCloseSignal_ = omnetpp::cComponent::registerSignal("traci.close");
-
 // Define static signal members for scene edit
 omnetpp::simsignal_t SionnaPythonHook::sceneEditBeginSignal_ = omnetpp::cComponent::registerSignal("sceneEditBegin");
 omnetpp::simsignal_t SionnaPythonHook::sceneEditEndSignal_ = omnetpp::cComponent::registerSignal("sceneEditEnd");
@@ -39,13 +34,7 @@ void SionnaPythonHook::initialize(int stage) {
         // Get parameters.
         pythonModulePath_ = par("pythonModulePath").stdstringValue();
 
-        // Get references to modules for signal subscription.
-        traciCoreModule_ = getModuleByPath(par("traciCoreModule").stringValue());
-        if (!traciCoreModule_) {
-            throw omnetpp::cRuntimeError("SionnaPythonHook: traciCoreModule not found at path '%s'",
-                                         par("traciCoreModule").stringValue());
-        }
-
+        // Get reference to scene config provider module for signal subscription.
         sceneConfigProviderModule_ = getModuleByPath(par("sceneConfigProviderModule").stringValue());
         if (!sceneConfigProviderModule_) {
             throw omnetpp::cRuntimeError("SionnaPythonHook: sceneConfigProviderModule not found at path '%s'",
@@ -56,10 +45,13 @@ void SionnaPythonHook::initialize(int stage) {
         // Load the Python module.
         loadPythonModule();
 
-        // Subscribe to TraCI signals.
-        traciCoreModule_->subscribe(traciInitSignal_, this);
-        traciCoreModule_->subscribe(traciStepSignal_, this);
-        traciCoreModule_->subscribe(traciCloseSignal_, this);
+        // Subscribe to TraCI signals using traci::Listener.
+        omnetpp::cModule* traciCoreModule = getModuleByPath(par("traciCoreModule").stringValue());
+        if (!traciCoreModule) {
+            throw omnetpp::cRuntimeError("SionnaPythonHook: traciCoreModule not found at path '%s'",
+                                         par("traciCoreModule").stringValue());
+        }
+        subscribeTraCI(traciCoreModule);
 
         // Subscribe to scene edit signals.
         sceneConfigProviderModule_->subscribe(sceneEditBeginSignal_, this);
@@ -68,13 +60,10 @@ void SionnaPythonHook::initialize(int stage) {
 }
 
 void SionnaPythonHook::finish() {
-    // Unsubscribe from signals.
-    if (traciCoreModule_) {
-        traciCoreModule_->unsubscribe(traciInitSignal_, this);
-        traciCoreModule_->unsubscribe(traciStepSignal_, this);
-        traciCoreModule_->unsubscribe(traciCloseSignal_, this);
-    }
+    // Unsubscribe from TraCI signals using traci::Listener.
+    unsubscribeTraCI();
 
+    // Unsubscribe from scene edit signals.
     if (sceneConfigProviderModule_) {
         sceneConfigProviderModule_->unsubscribe(sceneEditBeginSignal_, this);
         sceneConfigProviderModule_->unsubscribe(sceneEditEndSignal_, this);
@@ -184,26 +173,37 @@ void SionnaPythonHook::callPythonMethod(const std::string& methodName) {
 
         // Call the method.
         hook.attr(methodName.c_str())();
-        EV_DEBUG << "SionnaPythonHook: Called Python method '" << methodName << "'" << std::endl;
+        //EV_DEBUG << "SionnaPythonHook: Called Python method '" << methodName << "'" << std::endl;
+        EV_INFO << "SionnaPythonHook: Called Python method '" << methodName << "'" << std::endl;
 
     } catch (const nanobind::python_error& e) {
         EV_ERROR << "SionnaPythonHook: Error calling Python method '" << methodName << "': " << e.what() << std::endl;
     }
 }
 
-void SionnaPythonHook::receiveSignal(omnetpp::cComponent* /*source*/, omnetpp::simsignal_t signal,
-                                    const omnetpp::SimTime& /*value*/, omnetpp::cObject* /*details*/) {
-    if (signal == traciInitSignal_) {
-        callPythonMethod("on_traci_init");
-    } else if (signal == traciStepSignal_) {
-        callPythonMethod("on_traci_step");
-    } else if (signal == traciCloseSignal_) {
-        callPythonMethod("on_traci_close");
-    } else if (signal == sceneEditBeginSignal_) {
+void SionnaPythonHook::receiveSignal(omnetpp::cComponent* source, omnetpp::simsignal_t signal,
+                                     const omnetpp::SimTime& value, omnetpp::cObject* details) {
+    // Let traci::Listener handle TraCI signals (traciInit, traciStep, traciClose).
+    traci::Listener::receiveSignal(source, signal, value, details);
+
+    // Handle scene edit signals.
+    if (signal == sceneEditBeginSignal_) {
         onSceneEditBegin();
     } else if (signal == sceneEditEndSignal_) {
         onSceneEditEnd();
     }
+}
+
+void SionnaPythonHook::traciInit() {
+    callPythonMethod("on_traci_init");
+}
+
+void SionnaPythonHook::traciStep() {
+    callPythonMethod("on_traci_step");
+}
+
+void SionnaPythonHook::traciClose() {
+    callPythonMethod("on_traci_close");
 }
 
 void SionnaPythonHook::onSceneEditBegin() {

--- a/src/cavise/sionna/environment/hook/SionnaPythonHook.h
+++ b/src/cavise/sionna/environment/hook/SionnaPythonHook.h
@@ -1,0 +1,96 @@
+#pragma once
+
+#include <cavise/sionna/environment/hook/ISionnaPythonHook.h>
+#include <cavise/sionna/bridge/Helpers.h>
+
+#include <omnetpp/clistener.h>
+#include <omnetpp/csimplemodule.h>
+#include <omnetpp/simtime.h>
+
+#include <nanobind/nanobind.h>
+
+#include <string>
+#include <memory>
+
+namespace artery::sionna {
+
+    // A module that loads a user-specified Python module and calls its methods
+    // in response to various simulation events (TraCI signals, scene edits, etc.).
+    //
+    // The Python module should define a class (or module-level functions) with
+    // the following methods:
+    //
+    // class MyHook:
+    //     def on_traci_init(self):
+    //         """Called when TraCI initializes"""
+    //         pass
+    //
+    //     def on_traci_step(self):
+    //         """Called on each TraCI step"""
+    //         pass
+    //
+    //     def on_scene_edit_begin(self):
+    //         """Called before scene edit"""
+    //         pass
+    //
+    //     def on_scene_edit_end(self):
+    //         """Called after scene edit"""
+    //         pass
+    //
+    //     def on_traci_close(self):
+    //         """Called when TraCI closes"""
+    //         pass
+    //
+    class SionnaPythonHook : public ISionnaPythonHook, public omnetpp::cListener {
+    public:
+        SionnaPythonHook() = default;
+        ~SionnaPythonHook() override = default;
+
+        // omnetpp::cSimpleModule overrides.
+        int numInitStages() const override;
+        void initialize(int stage) override;
+        void finish() override;
+
+        // ISionnaPythonHook overrides.
+        void onPythonModuleLoaded() override {}
+        void onSceneEditBegin() override;
+        void onSceneEditEnd() override;
+
+        // omnetpp::cListener override.
+        void receiveSignal(omnetpp::cComponent* source, omnetpp::simsignal_t signal,
+                          const omnetpp::SimTime& value, omnetpp::cObject* details) override;
+
+    private:
+        // Load the Python module specified by the user.
+        void loadPythonModule();
+
+        // Call a method on the Python hook object.
+        void callPythonMethod(const std::string& methodName);
+
+    private:
+        // Path to the Python module (parameter).
+        std::string pythonModulePath_;
+
+        // The Python module object (imported).
+        std::unique_ptr<nanobind::object> pythonModule_;
+
+        // The Python hook class instance (if the module contains a class).
+        std::unique_ptr<nanobind::object> pythonHookInstance_;
+
+        // Cached signal IDs for TraCI.
+        static omnetpp::simsignal_t traciInitSignal_;
+        static omnetpp::simsignal_t traciStepSignal_;
+        static omnetpp::simsignal_t traciCloseSignal_;
+
+        // Cached signal IDs for scene edit.
+        static omnetpp::simsignal_t sceneEditBeginSignal_;
+        static omnetpp::simsignal_t sceneEditEndSignal_;
+
+        // Reference to the TraCI Core module (for subscribing to signals).
+        omnetpp::cModule* traciCoreModule_ = nullptr;
+
+        // Reference to the TraciDynamicSceneConfigProvider (for subscribing to scene edit signals).
+        omnetpp::cModule* sceneConfigProviderModule_ = nullptr;
+    };
+
+} // namespace artery::sionna

--- a/src/cavise/sionna/environment/hook/SionnaPythonHook.h
+++ b/src/cavise/sionna/environment/hook/SionnaPythonHook.h
@@ -86,9 +86,6 @@ namespace artery::sionna {
         // Cached signal IDs for scene edit.
         static omnetpp::simsignal_t sceneEditBeginSignal_;
         static omnetpp::simsignal_t sceneEditEndSignal_;
-
-        // Reference to the TraciDynamicSceneConfigProvider (for subscribing to scene edit signals).
-        omnetpp::cModule* sceneConfigProviderModule_ = nullptr;
     };
 
 } // namespace artery::sionna

--- a/src/cavise/sionna/environment/hook/SionnaPythonHook.h
+++ b/src/cavise/sionna/environment/hook/SionnaPythonHook.h
@@ -3,7 +3,8 @@
 #include <cavise/sionna/environment/hook/ISionnaPythonHook.h>
 #include <cavise/sionna/bridge/Helpers.h>
 
-#include <omnetpp/clistener.h>
+#include <traci/Listener.h>
+
 #include <omnetpp/csimplemodule.h>
 #include <omnetpp/simtime.h>
 
@@ -41,7 +42,7 @@ namespace artery::sionna {
     //         """Called when TraCI closes"""
     //         pass
     //
-    class SionnaPythonHook : public ISionnaPythonHook, public omnetpp::cListener {
+    class SionnaPythonHook : public ISionnaPythonHook, public traci::Listener {
     public:
         SionnaPythonHook() = default;
         ~SionnaPythonHook() override = default;
@@ -56,9 +57,14 @@ namespace artery::sionna {
         void onSceneEditBegin() override;
         void onSceneEditEnd() override;
 
-        // omnetpp::cListener override.
+        // traci::Listener override.
         void receiveSignal(omnetpp::cComponent* source, omnetpp::simsignal_t signal,
-                          const omnetpp::SimTime& value, omnetpp::cObject* details) override;
+                           const omnetpp::SimTime& value, omnetpp::cObject* details) override;
+
+        // traci::Listener virtual methods.
+        void traciInit() override;
+        void traciStep() override;
+        void traciClose() override;
 
     private:
         // Load the Python module specified by the user.
@@ -77,17 +83,9 @@ namespace artery::sionna {
         // The Python hook class instance (if the module contains a class).
         std::unique_ptr<nanobind::object> pythonHookInstance_;
 
-        // Cached signal IDs for TraCI.
-        static omnetpp::simsignal_t traciInitSignal_;
-        static omnetpp::simsignal_t traciStepSignal_;
-        static omnetpp::simsignal_t traciCloseSignal_;
-
         // Cached signal IDs for scene edit.
         static omnetpp::simsignal_t sceneEditBeginSignal_;
         static omnetpp::simsignal_t sceneEditEndSignal_;
-
-        // Reference to the TraCI Core module (for subscribing to signals).
-        omnetpp::cModule* traciCoreModule_ = nullptr;
 
         // Reference to the TraciDynamicSceneConfigProvider (for subscribing to scene edit signals).
         omnetpp::cModule* sceneConfigProviderModule_ = nullptr;

--- a/src/cavise/sionna/environment/hook/SionnaPythonHook.h
+++ b/src/cavise/sionna/environment/hook/SionnaPythonHook.h
@@ -12,6 +12,7 @@
 
 #include <string>
 #include <memory>
+#include <vector>
 
 namespace artery::sionna {
 
@@ -67,21 +68,30 @@ namespace artery::sionna {
         void traciClose() override;
 
     private:
-        // Load the Python module specified by the user.
+        // Load the Python module(s) or package specified by the user.
         void loadPythonModule();
 
-        // Call a method on the Python hook object.
+        // Load a single Python module and discover hook classes.
+        void loadSingleModule(const std::string& modulePath);
+
+        // Load all Python modules from a package directory.
+        void loadPackage(const std::string& packagePath);
+
+        // Discover and instantiate hook classes in a module.
+        void discoverHooksInModule(const nanobind::object& module);
+
+        // Call a method on all Python hook instances.
         void callPythonMethod(const std::string& methodName);
 
     private:
-        // Path to the Python module (parameter).
+        // Path to the Python module or package (parameter).
         std::string pythonModulePath_;
 
-        // The Python module object (imported).
-        std::unique_ptr<nanobind::object> pythonModule_;
+        // The Python module objects (imported).
+        std::vector<std::unique_ptr<nanobind::object>> pythonModules_;
 
-        // The Python hook class instance (if the module contains a class).
-        std::unique_ptr<nanobind::object> pythonHookInstance_;
+        // The Python hook class instances.
+        std::vector<std::unique_ptr<nanobind::object>> pythonHookInstances_;
 
         // Cached signal IDs for scene edit.
         static omnetpp::simsignal_t sceneEditBeginSignal_;

--- a/src/cavise/sionna/environment/hook/SionnaPythonHook.ned
+++ b/src/cavise/sionna/environment/hook/SionnaPythonHook.ned
@@ -1,0 +1,46 @@
+package cavise.sionna.environment.hook;
+
+import inet.common.InitStages;
+
+@namespace(artery::sionna);
+@class(SionnaPythonHook);
+
+//
+// A module that loads a user-specified Python module and calls its methods
+// in response to various simulation events (TraCI signals, scene edits, etc.).
+//
+// The Python module should define a class or functions with the following methods:
+//
+// class MyHook:
+//     def on_traci_init(self):
+//         """Called when TraCI initializes"""
+//         pass
+//
+//     def on_traci_step(self):
+//         """Called on each TraCI step"""
+//         pass
+//
+//     def on_scene_edit_begin(self):
+//         """Called before scene edit"""
+//         pass
+//
+//     def on_scene_edit_end(self):
+//         """Called after scene edit"""
+//         pass
+//
+//     def on_traci_close(self):
+//         """Called when TraCI closes"""
+//         pass
+//
+// Alternatively, you can define a module-level 'hook' attribute that points to
+// an instance of your hook class, or just define the functions at module level.
+//
+simple SionnaPythonHook like ISionnaPythonHook
+{
+    parameters:
+        string pythonModulePath;  // Path to the Python module (file path or import path)
+        string traciCoreModule;     // Path to the TraCI Core module (for subscribing to signals)
+        string sceneConfigProviderModule;  // Path to the TraciDynamicSceneConfigProvider module
+
+        @display("i=block/function");
+}

--- a/src/cavise/sionna/environment/hook/SionnaPythonHook.ned
+++ b/src/cavise/sionna/environment/hook/SionnaPythonHook.ned
@@ -40,7 +40,6 @@ simple SionnaPythonHook like ISionnaPythonHook
     parameters:
         string pythonModulePath;  // Path to the Python module (file path or import path)
         string traciCoreModule;     // Path to the TraCI Core module (for subscribing to signals)
-        string sceneConfigProviderModule;  // Path to the TraciDynamicSceneConfigProvider module
 
         @display("i=block/function");
 }

--- a/src/cavise/sionna/environment/hook/SionnaPythonHook.ned
+++ b/src/cavise/sionna/environment/hook/SionnaPythonHook.ned
@@ -6,40 +6,46 @@ import inet.common.InitStages;
 @class(SionnaPythonHook);
 
 //
-// A module that loads a user-specified Python module and calls its methods
-// in response to various simulation events (TraCI signals, scene edits, etc.).
+// A module that loads a user-specified Python module or package and calls
+// its methods in response to various simulation events (TraCI signals,
+// scene edits, etc.).
 //
-// The Python module should define a class or functions with the following methods:
+// The pythonModulePath parameter can be:
+// 1. A single Python file path (e.g., "/path/to/my_hook.py")
+// 2. A Python package directory containing multiple hook modules
 //
-// class MyHook:
-//     def on_traci_init(self):
-//         """Called when TraCI initializes"""
-//         pass
+// Hook classes can be defined in several ways:
 //
-//     def on_traci_step(self):
-//         """Called on each TraCI step"""
-//         pass
+// 1. Using the @sionna_hook decorator (recommended):
+//    from cavise.sionna.environment.hook.decorators import sionna_hook
 //
-//     def on_scene_edit_begin(self):
-//         """Called before scene edit"""
-//         pass
+//    @sionna_hook
+//    class MyHook:
+//        def on_traci_init(self):
+//            print("TraCI initialized")
 //
-//     def on_scene_edit_end(self):
-//         """Called after scene edit"""
-//         pass
+// 2. Defining a class named 'Hook' (backward compatible)
 //
-//     def on_traci_close(self):
-//         """Called when TraCI closes"""
-//         pass
+// 3. Defining a module-level 'hook' attribute (backward compatible)
 //
-// Alternatively, you can define a module-level 'hook' attribute that points to
-// an instance of your hook class, or just define the functions at module level.
+// 4. Defining functions at module level (backward compatible)
+//
+// When loading a package directory, all Python files (except __init__.py)
+// are imported and scanned for @sionna_hook decorated classes. All decorated
+// classes are instantiated and their methods are called in sequence.
+//
+// Required hook methods:
+//     def on_traci_init(self):      # Called when TraCI initializes
+//     def on_traci_step(self):      # Called on each TraCI step
+//     def on_scene_edit_begin(self): # Called before scene edit
+//     def on_scene_edit_end(self):   # Called after scene edit
+//     def on_traci_close(self):     # Called when TraCI closes
 //
 simple SionnaPythonHook like ISionnaPythonHook
 {
     parameters:
-        string pythonModulePath;  // Path to the Python module (file path or import path)
-        string traciCoreModule;     // Path to the TraCI Core module (for subscribing to signals)
+        string pythonModulePath;  // Path to Python module file or package directory
+        string traciCoreModule;   // Path to the TraCI Core module (for subscribing to signals)
 
         @display("i=block/function");
 }

--- a/src/cavise/sionna/environment/hook/decorators.py
+++ b/src/cavise/sionna/environment/hook/decorators.py
@@ -1,0 +1,50 @@
+"""
+Decorators for marking Sionna Python hook classes.
+
+This module provides decorators that can be used to mark classes as Sionna hooks.
+When a package/directory is loaded, the SionnaPythonHook will discover and
+instantiate all decorated classes.
+"""
+
+def sionna_hook(cls):
+    """
+    Decorator to mark a class as a Sionna Python hook.
+
+    Classes decorated with @sionna_hook will be automatically discovered and
+    instantiated when loading a Python package/directory.
+
+    Example usage:
+        from cavise.sionna.environment.hook.decorators import sionna_hook
+
+        @sionna_hook
+        class MyCustomHook:
+            def on_traci_init(self):
+                print("TraCI initialized")
+
+            def on_traci_step(self):
+                pass
+
+            def on_scene_edit_begin(self):
+                pass
+
+            def on_scene_edit_end(self):
+                pass
+
+            def on_traci_close(self):
+                pass
+    """
+    cls._sionna_hook_marked = True
+    return cls
+
+
+def is_sionna_hook(cls):
+    """
+    Check if a class is marked as a Sionna hook.
+
+    Args:
+        cls: The class to check
+
+    Returns:
+        True if the class is marked with @sionna_hook
+    """
+    return getattr(cls, '_sionna_hook_marked', False)

--- a/src/cavise/sionna/environment/hook/example_hook.py
+++ b/src/cavise/sionna/environment/hook/example_hook.py
@@ -8,7 +8,6 @@ Usage in omnetpp.ini:
     *.physicalEnvironment.pythonHookType = "cavise.sionna.environment.hook.SionnaPythonHook"
     *.physicalEnvironment.pythonHook.pythonModulePath = "${ARTERY_ROOT}/src/cavise/sionna/environment/hook/example_hook.py"
     *.physicalEnvironment.pythonHook.traciCoreModule = "traci.core"
-    *.physicalEnvironment.pythonHook.sceneConfigProviderModule = "physicalEnvironment.dynamicSceneConfigProvider"
 """
 
 class MyHook:

--- a/src/cavise/sionna/environment/hook/example_hook.py
+++ b/src/cavise/sionna/environment/hook/example_hook.py
@@ -1,0 +1,48 @@
+"""
+Example Python hook for SionnaPhysicalEnvironment.
+
+This module demonstrates how to use the SionnaPythonHook to react to
+simulation events. To use this hook, set the pythonModulePath parameter to this file.
+
+Usage in omnetpp.ini:
+    *.physicalEnvironment.pythonHookType = "cavise.sionna.environment.hook.SionnaPythonHook"
+    *.physicalEnvironment.pythonHook.pythonModulePath = "${ARTERY_ROOT}/src/cavise/sionna/environment/hook/example_hook.py"
+    *.physicalEnvironment.pythonHook.traciCoreModule = "traci.core"
+    *.physicalEnvironment.pythonHook.sceneConfigProviderModule = "physicalEnvironment.dynamicSceneConfigProvider"
+"""
+
+class MyHook:
+    """
+    Hook class that gets instantiated by SionnaPythonHook.
+    Alternatively, you can define a module-level 'hook' attribute pointing to an instance,
+    or just define the functions at module level.
+    """
+
+    def __init__(self):
+        self.step_count = 0
+        print("MyHook: Initialized")
+
+    def on_traci_init(self):
+        """Called when TraCI initializes."""
+        print("MyHook: TraCI initialized")
+
+    def on_traci_step(self):
+        """Called on each TraCI step."""
+        self.step_count += 1
+        if self.step_count % 10 == 0:
+            print(f"MyHook: TraCI step {self.step_count}")
+
+    def on_scene_edit_begin(self):
+        """Called before scene edit."""
+        print("MyHook: Scene edit begin")
+
+    def on_scene_edit_end(self):
+        """Called after scene edit."""
+        print("MyHook: Scene edit end")
+
+    def on_traci_close(self):
+        """Called when TraCI closes."""
+        print("MyHook: TraCI closing")
+
+# If you want to use a module-level instance, you can do:
+# hook = MyHook()

--- a/src/cavise/sionna/environment/hook/example_hook.py
+++ b/src/cavise/sionna/environment/hook/example_hook.py
@@ -1,20 +1,35 @@
 """
-Example Python hook for SionnaPhysicalEnvironment.
+Example Python hooks for SionnaPhysicalEnvironment.
 
 This module demonstrates how to use the SionnaPythonHook to react to
-simulation events. To use this hook, set the pythonModulePath parameter to this file.
+simulation events. There are multiple ways to define hooks:
 
-Usage in omnetpp.ini:
+1. Using the @sionna_hook decorator (recommended for new code)
+2. Defining a class named 'Hook' (backward compatible)
+3. Defining a module-level 'hook' attribute (backward compatible)
+4. Defining functions at module level (backward compatible)
+
+To use a single hook file, set in omnetpp.ini:
     *.physicalEnvironment.pythonHookType = "cavise.sionna.environment.hook.SionnaPythonHook"
     *.physicalEnvironment.pythonHook.pythonModulePath = "${ARTERY_ROOT}/src/cavise/sionna/environment/hook/example_hook.py"
     *.physicalEnvironment.pythonHook.traciCoreModule = "traci.core"
+
+To use a package with multiple hooks, create a directory with multiple
+Python files, each containing @sionna_hook decorated classes:
+    *.physicalEnvironment.pythonHook.pythonModulePath = "${ARTERY_ROOT}/path/to/hooks_package"
 """
 
+"""
+Later do something like ```cavise.sionna.environment.hook.decorators```
+"""
+from decorators import sionna_hook
+
+
+@sionna_hook
 class MyHook:
     """
-    Hook class that gets instantiated by SionnaPythonHook.
-    Alternatively, you can define a module-level 'hook' attribute pointing to an instance,
-    or just define the functions at module level.
+    Hook class using the @sionna_hook decorator.
+    This is the recommended way to define hooks.
     """
 
     def __init__(self):
@@ -43,5 +58,32 @@ class MyHook:
         """Called when TraCI closes."""
         print("MyHook: TraCI closing")
 
-# If you want to use a module-level instance, you can do:
+
+@sionna_hook
+class AnotherHook:
+    """
+    Another hook class in the same module.
+    Both MyHook and AnotherHook will be discovered and instantiated.
+    """
+
+    def __init__(self):
+        print("AnotherHook: Initialized")
+
+    def on_traci_init(self):
+        print("AnotherHook: TraCI initialized")
+
+    def on_traci_step(self):
+        print("AnotherHook: TraCI step")
+
+    def on_scene_edit_begin(self):
+        print("AnotherHook: Scene edit begin")
+
+    def on_scene_edit_end(self):
+        print("AnotherHook: Scene edit end")
+
+    def on_traci_close(self):
+        print("AnotherHook: TraCI closing")
+
+
+# For backward compatibility, you can also define a module-level instance:
 # hook = MyHook()

--- a/src/cavise/sionna/environment/hook/package.ned
+++ b/src/cavise/sionna/environment/hook/package.ned
@@ -1,0 +1,3 @@
+package cavise.sionna.environment.hook;
+
+@namespace(artery::sionna);


### PR DESCRIPTION
A new module has been implemented that allows you to hook events and handle them using a Python script
List of events:
```
traci.init
traci.step
traci.close
sceneEditBegin
sceneEditEnd
```
An example script is provided in ```src/cavise/sionna/environment/hook/example_hook.py```
The default handler class is defined by the ```hook``` variable

closes #58